### PR TITLE
Add API to show error messages from failed token fetches

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -609,38 +609,6 @@ dictionary DisconnectedAccount {
   required USVString account_id;
 };
 </xmp>
-## The IdentityCredentialError Interface ## {#browser-api-identity-credential-error-interface}
-<!-- ============================================================ -->
-
-This specification introduces a new type of {{DOMException}}, the {{IdentityCredentialError}}. It
-is used when the [=IDP=] cannot create an {{IdentityCredential}} after the user has requested to use
-a federated account.
-
-<pre class="idl">
-  [Exposed=Window, SecureContext]
-  interface IdentityCredentialError: DOMException {
-    constructor(optional DOMString message = "", IdentityCredentialErrorInit options);
-    readonly attribute DOMString code;
-    readonly attribute DOMString url;
-  };
-</pre>
-
-<div algorithm="IdentityCredentialError constructor">
-The {{IdentityCredentialError/constructor()}}, given a |realm|, a {{DOMString}} |message| and a
-    {{IdentityCredentialErrorInit}} |options| must run the following steps:
-    1. Invoke the {{DOMException}}'s {{DOMException/constructor()}}, passing |realm| and |message|.
-    1. Set <a>this</a>.{{IdentityCredentialError/code}} to |options|.{{IdentityCredentialError/code}}.
-    1. Set <a>this</a>.{{IdentityCredentialError/url}} to |options.{{IdentityCredentialError/url}}.
-</div>
-
-<dl>
-    :   <b>{{IdentityCredentialError/code}}</b>
-    ::  The {{IdentityCredentialError/code}}'s attribute getter returns the value it is set to.
-        It represents the type of error which resulted in an {{IdentityCredential}} not being created.
-    :   <b>{{IdentityCredentialError/url}}</b>
-    ::  The {{IdentityCredentialError/url}}'s attribute getter returns the value it is set to.
-        It represents a URL where the user can learn more information about the error.
-</dl>
 
 <!-- ============================================================ -->
 ## The IdentityCredentialError Interface ## {#browser-api-identity-credential-error-interface}
@@ -1579,13 +1547,6 @@ An extension may add the following steps after the [=fetch identity assertion/cr
 dictionary IdentityAssertionResponse {
   USVString token;
   USVString continue_on;
-};
-</xmp>
-
-<xmp class="idl">
-dictionary IdentityCredentialErrorInit {
-  DOMString code;
-  DOMString url;
 };
 </xmp>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -635,8 +635,8 @@ dictionary IdentityCredentialErrorInit {
 </pre>
 
 <div algorithm="IdentityCredentialError constructor">
-The {{IdentityCredentialError/constructor()}}, given a |realm|, a {{DOMString}} |message| and a
-    {{IdentityCredentialErrorInit}} |options| must run the following steps:
+Given a |realm|, a {{DOMString}} |message|, and an {{IdentityCredentialErrorInit}} |options|, the
+{{IdentityCredentialError/constructor()}} must run the following steps:
     1. Invoke the {{DOMException}}'s {{DOMException/constructor()}}, passing |realm| and |message|.
     1. Set <a>this</a>.{{IdentityCredentialError/error}} to |options|.{{IdentityCredentialError/error}}
         if it is present in |options|, or to "" otherwise.
@@ -826,7 +826,7 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
                 However, UAs may have different UI approaches here and prevent it in a different way.
         1. [=Queue a global task=] on the [=DOM manipulation task source=]
             to throw a new "{{NetworkError}}" {{DOMException}}.
-    1. Otherwise, return |credential| (this may throw since it may be an
+    1. Else, return |credential| (this may throw, since it may be an
         {{IdentityCredentialError}}).
 </div>
 
@@ -1036,8 +1036,8 @@ throwing the exception.
             the user agent MAY show some UI to the user indicating that they are being
             <dfn>auto-reauthenticated</dfn>.
         1. Set |isAutoSelected| to true.
-    1. Otherwise, if |mediation| is "{{CredentialMediationRequirement/silent}}", return (failure, false).
-    1. Otherwise, if |accountsList|'s size is 1:
+    1. Else if |mediation| is "{{CredentialMediationRequirement/silent}}", return (failure, false).
+    1. Else if |accountsList|'s size is 1:
         1. Set |account| to |accountsList|[0].
         1. Set |accountState| to the result of running the [=compute the connection status=] algorithm
             given |provider|, |account|, and |globalObject|.
@@ -1045,10 +1045,10 @@ throwing the exception.
             let |permission| be the result of running [=request permission to sign-up=] algorithm
             with |account|, |accountState|, |config|, |provider|, and |globalObject|. Also set
             |disclosureTextShown| to true.
-        1. Otherwise, show a dialog to request user permission to sign in via |account|, and set the
+        1. Else, show a dialog to request user permission to sign in via |account|, and set the
             result in |permission|. The user agent MAY use |options|'s
             {{IdentityCredentialRequestOptions/context}} to customize the dialog.
-    1. Otherwise:
+    1. Else:
         1. Set |account| to the result of running the [=select an account=] from the
             |accountsList|.
         1. If |account| is failure, return (failure, true).
@@ -1058,7 +1058,7 @@ throwing the exception.
             1. Let |permission| be the result of running the [=request permission to sign-up=]
                 algorithm with |account|, |config|, |provider|, and |globalObject|.
             1. Set |disclosureTextShown| to true.
-        1. Otherwise, set |permission| to true.
+        1. Else, set |permission| to true.
     1. Wait until the [=user agent=]'s dialogs requesting for user choice or permission to be
         closed, if any are created in the previous steps.
     1. Assert: |account| is not null.
@@ -1080,8 +1080,8 @@ throwing the exception.
             in its UI so the user can click on it to learn more information about the error message.
         1. Wait until the UI is acknowledged or dismissed by the user.
         
-        Note: this wait means the [=user agent=] rejects the call only after the UI has been
-            closed by the user.
+          Note: this wait means the [=user agent=] rejects the call only after the UI has been
+              closed by the user.
     1. Return |credential|.
 </div>
 
@@ -1500,7 +1500,7 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
         1. Otherwise, i.e. if |json|[|error|] [=map/exists=]:
             1. If |json|[|error|] is not an [=ordered map=], set |credential| to a new
                 {{IdentityCredentialError}} given |globalObject|'s [=global object/realm=] and
-                "IdentityCredentialError" and return.
+                "IdentityCredentialError", and return.
             1. [=converted to an IDL value|Convert=] |json| to an {{IdentityCredentialErrorInit}},
                 |errorInit|.
             1. If |errorInit|.{{IdentityCredentialErrorInit/url}} is present:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -611,6 +611,40 @@ dictionary DisconnectedAccount {
 </xmp>
 
 <!-- ============================================================ -->
+## The IdentityCredentialError Interface ## {#browser-api-identity-credential-error-interface}
+<!-- ============================================================ -->
+
+This specification introduces a new type of {{DOMException}}, the {{IdentityCredentialError}}. It
+is used when the [=IDP=] cannot create an {{IdentityCredential}} after the user has requested to use
+a federated account.
+
+<pre class="idl">
+  [Exposed=Window, SecureContext]
+  interface IdentityCredentialError: DOMException {
+    constructor(optional DOMString message = "", IdentityCredentialErrorInit options);
+    readonly attribute DOMString code;
+    readonly attribute DOMString url;
+  };
+</pre>
+
+<div algorithm="IdentityCredentialError constructor">
+The {{IdentityCredentialError/constructor()}}, given a |realm|, a {{DOMString}} |message| and a
+    {{IdentityCredentialErrorInit}} |options| must run the following steps:
+    1. Invoke the {{DOMException}}'s {{DOMException/constructor()}}, passing |realm| and |message|.
+    1. Set <a>this</a>.{{IdentityCredentialError/code}} to |options|.{{IdentityCredentialError/code}}.
+    1. Set <a>this</a>.{{IdentityCredentialError/url}} to |options.{{IdentityCredentialError/url}}.
+</div>
+
+<dl>
+    :   <b>{{IdentityCredentialError/code}}</b>
+    ::  The {{IdentityCredentialError/code}}'s attribute getter returns the value it is set to.
+        It represents the type of error which resulted in an {{IdentityCredential}} not being created.
+    :   <b>{{IdentityCredentialError/url}}</b>
+    ::  The {{IdentityCredentialError/url}}'s attribute getter returns the value it is set to.
+        It represents a URL where the user can learn more information about the error.
+</dl>
+
+<!-- ============================================================ -->
 ### The CredentialRequestOptions ### {#browser-api-credential-request-options}
 <!-- ============================================================ -->
 
@@ -745,7 +779,7 @@ requests.
 When the {{IdentityCredential}}'s
 <dfn for="IdentityCredential" method>\[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)</dfn>
 algorithm is invoked, the user agent MUST execute the following steps. This returns an
-{{IdentityCredential}} (or throws an error to the caller).
+{{IdentityCredential}} or throws an error to the caller.
 
     1. Assert: These steps are running [=in parallel=].
     1. If
@@ -765,10 +799,10 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
         algorithm. See <a href="https://github.com/w3c/webappsec-credential-management/issues/210">issue</a>.
 
     1. If |credential| is a pair:
-        1. Let |throwImmediately| be the value of the second element of the pair.
+        1. Let |delayException| be the value of the second element of the pair.
         1. The user agent SHOULD wait a random amount of time
             before the next step if all of the following conditions hold:
-            * |throwImmediately| is false
+            * |delayException| is true
             * The <dfn>promise rejection delay</dfn> was not disabled by
                 [=setdelayenabled|user agent automation=]
             * The user agent has not implemented another way to prevent
@@ -783,7 +817,8 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
                 However, UAs may have different UI approaches here and prevent it in a different way.
         1. [=Queue a global task=] on the [=DOM manipulation task source=]
             to throw a new "{{NetworkError}}" {{DOMException}}.
-    1. Otherwise, return |credential|.
+    1. Otherwise, return |credential| (this may throw since it may be an
+        {{IdentityCredentialError}}).
 </div>
 
 <!-- ============================================================ -->
@@ -791,14 +826,15 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
 <!-- ============================================================ -->
 
 The <a>create an IdentityCredential</a> algorithm invokes the various FedCM fetches, shows the user
-agent UI, and creates the {{IdentityCredential}} that is then returned to the [=RP=].
+agent UI, and creates the {{IdentityCredential}} or {{IdentityCredentialError}} which is then
+returned to the [=RP=].
 
 <div algorithm="create an IdentityCredential">
-To <dfn>create an IdentityCredential</dfn> given a [=sequence=] of  {{IdentityProviderRequestOptions}}
-|providerList|, a {{CredentialRequestOptions}} |options|, and a
-|globalObject|, run the following steps. This returns an {{IdentityCredential}}
-or a pair (failure, bool), where the bool indicates whether to skip delaying
-the exception thrown.
+To <dfn>create an IdentityCredential</dfn> given an {{IdentityProviderRequestOptions}}
+|provider|, a {{CredentialRequestOptions}} |options|, and a
+|globalObject|, run the following steps. This returns an {{IdentityCredential}}, an
+{{IdentityCredentialError}}, or a pair (failure, bool), where the bool indicates whether to delay
+throwing the exception.
     1. Assert: These steps are running [=in parallel=].
     1. Let |mode| be |options|'s {{IdentityCredentialRequestOptions/mode}}.
     1. If |mode| is {{IdentityCredentialRequestOptionsMode/active}}:
@@ -942,26 +978,101 @@ the exception thrown.
 
             * If the [=show an IDP login dialog=] algorithm was triggered:
 
-                1. Let |result| be the result of that algorithm.
-                1. If |result| is failure, return (failure, true). The user
-                    agent MAY show a dialog to the user before or after
-                    returning failure indicating this failure.
-                1. Otherwise, go back to the [=fetch accounts step=] to get an updated
-                    value of |providerMap| for this [=IDP=].
-        1. Otherwise, |value| is a [=list=] of accounts. [=list/Extend=] |allAccounts| with |value|.
-    1. Also include a UI affordance to close the dialog. If the user closes this dialog, return (failure,
-        true).
-    1. <dfn for="create identity credential">Show accounts</dfn> step: if |allAccounts| is not [=list/empty=], also add UI to present the account options to the user.
-        If the user selects an account, perform the following steps:
-            1. Set |selectedAccount| to the chosen {{IdentityProviderAccount}}.
-            1. Close the dialog.
-    1. If the [=user agent=] created any dialogs requesting user choice or permission in the previous
-        steps, wait until they are closed.
+                * If the user closes the dialog, return (failure, true).
+
+                * If the [=show an IDP login dialog=] algorithm was triggered:
+
+                    1. Let |result| be the result of that algorithm.
+                    1. If |result| is failure, return (failure, true). The user
+                        agent MAY show a dialog to the user before or after
+                        returning failure indicating this failure.
+                    1. Otherwise, go back to the [=fetch accounts step=].
+
+    1. Assert: |accountsList| is not failure and the size of |accountsList| is not 0.
+    1. [=Set the login status=] for the [=/origin=] of the
+        {{IdentityProviderConfig/configURL}} to [=logged-in=].
+    1. If |provider|'s {{IdentityProviderRequestOptions/loginHint}} is not empty:
+        1. For every |account| in |accountList|, remove |account| from |accountList| if |account|'s
+            {{IdentityProviderAccount/login_hints}} does not [=list/contain=] |provider|'s
+            {{IdentityProviderRequestOptions/loginHint}}.
+        1. If |accountList| is now empty, go to the [=mismatch dialog step=].
+    1. If |provider|'s {{IdentityProviderRequestOptions/domainHint}} is not empty:
+        1. For every |account| in |accountList|:
+            1. If {{IdentityProviderRequestOptions/domainHint}} is "any":
+                1. If |account|'s {{IdentityProviderAccount/domain_hints}} is empty, remove
+                    |account| from |accountList|.
+            1. Otherwise, remove |account| from |accountList| if |account|'s
+                {{IdentityProviderAccount/domain_hints}} does not [=list/contain=] |provider|'s
+                {{IdentityProviderRequestOptions/domainHint}}.
+        1. If |accountList| is now empty, go to the [=mismatch dialog step=].
+    1. For each |acc| in |accountsList|:
+        1. If |acc|["{{IdentityProviderAccount/picture}}"] is present, [=fetch the account picture=]
+            with |acc| and |globalObject|.
+
+        Note: The [=user agent=] may choose to show UI which does not initially require fetching the
+        account pictures. In these cases, the [=user agent=] may delay these fetches until they are
+        needed. Because errors from these fetches are ignored, they can happen in any order.
+    1. Let |registeredAccount|, |numRegisteredAccounts| be null and 0, respectively.
+    1. Let |account| be null.
+    1. For each |acc| in |accountsList|:
+        1. Let |accState| be the result of running the [=compute the connection status=] algorithm given
+            |provider| and |acc|.
+        1. If |accState| is [=compute the connection status/connected=], set |registeredAccount| to
+            |acc| and increase |numRegisteredAccounts| by 1.
+    1. Let |permission|, |disclosureTextShown|, and |isAutoSelected| be set to false.
+    1. If |mediation| is not "{{CredentialMediationRequirement/required}}", |requiresUserMediation|
+        is false, and |numRegisteredAccounts| is equal to 1:
+        1. Set |account| to |registeredAccount| and |accountState| to the result of running
+            [=compute the connection status=] algorithm given |provider| and |account|. When doing this,
+            the user agent MAY show some UI to the user indicating that they are being
+            <dfn>auto-reauthenticated</dfn>.
+        1. Set |isAutoSelected| to true.
+    1. Otherwise, if |mediation| is "{{CredentialMediationRequirement/silent}}", return (failure, false).
+    1. Otherwise, if |accountsList|'s size is 1:
+        1. Set |account| to |accountsList|[0].
+        1. Set |accountState| to the result of running the [=compute the connection status=] algorithm
+            given |provider|, |account|, and |globalObject|.
+        1. If |accountState| is [=compute the connection status/disconnected=],
+            let |permission| be the result of running [=request permission to sign-up=] algorithm
+            with |account|, |accountState|, |config|, |provider|, and |globalObject|. Also set
+            |disclosureTextShown| to true.
+        1. Otherwise, show a dialog to request user permission to sign in via |account|, and set the
+            result in |permission|. The user agent MAY use |options|'s
+            {{IdentityCredentialRequestOptions/context}} to customize the dialog.
+    1. Otherwise:
+        1. Set |account| to the result of running the [=select an account=] from the
+            |accountsList|.
+        1. If |account| is failure, return (failure, true).
+        1. Set |accountState| to the result of running the [=compute the connection status=] algorithm
+            given |provider| and |account|.
+        1. If |accountState| is [=compute the connection status/disconnected=]:
+            1. Let |permission| be the result of running the [=request permission to sign-up=]
+                algorithm with |account|, |config|, |provider|, and |globalObject|.
+            1. Set |disclosureTextShown| to true.
+        1. Otherwise, set |permission| to true.
+    1. Wait until the [=user agent=]'s dialogs requesting for user choice or permission to be
+        closed, if any are created in the previous steps.
+    1. Assert: |account| is not null.
     1. If |permission| is false, then return (failure, true).
     1. Assert: |selectedAccount| is not null.
     1. Let |credential| be the result of running the [=fetch an identity assertion=] algorithm with
         |selectedAccount|'s {{IdentityProviderAccount/id}}, |permissionRequested|, |isAutoSelected|,
         |provider|, |config|, and |globalObject|.
+    1. If |credential| is an {{IdentityCredentialError}}:
+        1. The [=user agent=] MUST show UI to the user indicating that the identity assertion fetch
+            has failed.
+        1. The [=user agent=] MAY use the {{IdentityCredentialError/code}} in its UI to provide a
+            more specific error message to the user. For instance, if the value is one of
+            "invalid_request", "unauthorized_client", "access_denied", "server_error", and
+            "temporarily_unavailable", the [=user agent=] may note the reason in a user-friendly
+            manner. See [here](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) for
+            more details about these.
+        1. The [=user agent=] MAY use the {{IdentityCredentialError/url}} to display a hyperlink
+            in its UI so the user can click on it to learn more information about the error message.
+        1. Wait until the UI is acknowledged or dismissed by the user.
+        
+        Note: this wait means the [=user agent=] rejects the call only after the UI has been
+            dismissed by the user.
     1. Return |credential|.
 </div>
 
@@ -1308,7 +1419,7 @@ To <dfn>fetch the account picture</dfn> given an {{IdentityProviderAccount}} |ac
 
 The <a>fetch an identity assertion</a> algorithm is invoked after the user has granted permission to
 use FedCM with a specific [=IDP=] account. It fetches the [=identity assertion endpoint=] to obtain
-the token that will be provided to the [=RP=].
+the token or error that will be provided to the [=RP=].
 
 <div algorithm="fetch an identity assertion">
 To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
@@ -1317,8 +1428,12 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
     and |globalObject|, run the following steps. This returns an {{IdentityCredential}} or failure.
     1. Let |tokenUrl| be the result of [=computing the manifest URL=] given |provider|,
         |config|["{{IdentityProviderAPIConfig/id_assertion_endpoint}}"], and |globalObject|.
-    1. If |tokenUrl| is failure, return failure.
-    1. <dfn for="fetch identity assertion">Create a list</dfn>: let |list| be a list with the following entries:
+    1. If |tokenUrl| is failure:
+        1. [=Queue a global task=] on the [=DOM manipulation task source=] given |globalObject| to
+            let |error| be a new {{IdentityCredentialError}} given |globalObject|'s
+            <a for="global object">realm</a>.
+        1. Wait for |error| to be set, and return it.
+    1. Let |requestBody| be the result of running [=urlencoded serializer=] with a list containing:
         1. ("client_id", |provider|'s {{IdentityProviderConfig/clientId}})
         1. ("nonce", |provider|'s {{IdentityProviderRequestOptions/nonce}})
         1. ("account_id",  |accountId|)
@@ -1360,37 +1475,25 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
         set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
         1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
             |responseBody|.
-        1. [=converted to an IDL value|Convert=] |json| to an {{IdentityAssertionResponse}}, |token|.
-        1. If one of the previous two steps threw an exception, set |credential| to failure
-            and return.
-        1. If neither {{IdentityAssertionResponse/token}} nor
-            {{IdentityAssertionResponse/continue_on}} was specified, set |credential| to failure
-            and return.
-        1. If {{IdentityAssertionResponse/token}} was specified, let |tokenString|
-            be |token|'s {{IdentityAssertionResponse/token}}.
-        1.  Otherwise, run these steps [=in parallel=]:
-            1. Let |continueOnUrl| be the result of running [=parse url=] with |token|'s
-                {{IdentityAssertionResponse/continue_on}} and |globalObject|.
-            1. If |continueOnUrl| is failure, set |credential| to failure and return.
-            1. If |continueOnUrl| is not [=same origin=] with |tokenUrl|, set |credential|
-                to failure and return.
-            1. Let |tokenPair| be the result of [=show a continuation dialog=] with |continueOnUrl|.
-            1. If |tokenPair| is failure, set |credential| to failure and return.
-            1. Let |tokenString| be the first entry of |tokenPair|.
-            1. If the second entry of |tokenPair| is not null, set |accountId| to that second entry.
-        1. Wait for |tokenString| or |credential| to be set.
-        1. If |credential| is set:
-            1. Assert that |credential| is set to failure.
-            1. Return |credential|.
-        1. [=Create a connection between the RP and the IdP account=] with |provider|, |accountId|, and
-            |globalObject|.
-        1. Let |credential| be a new {{IdentityCredential}} given |globalObject|'s
-            <a for="global object">realm</a>.
-        1. Set |credential|'s {{IdentityCredential/token}} to |tokenString|.
-        1. Set |credential|'s {{IdentityCredential/isAutoSelected}} to
-            |isAutoSelected|.
-        1. Set |credential|'s {{IdentityCredential/configURL}} to |provider|'s
-            {{IdentityProviderConfig/configURL}}.
+        1. If |json|[|token|] and |json|[|error|] both [=map/exist=] or both do not [=map/exist=],
+            set |credential| to a new {{IdentityCredentialError}} given |globalObject|'s
+            <a for="global object">realm</a> and "IdentityCredentialError", and return.
+        1. If |json|[|token|] [=map/exists=]:
+            1. [=converted to an IDL value|Convert=] |json| to an {{IdentityProviderToken}}, |token|.
+            1. If one of the previous steps threw an exception, set |credential| to a new
+                {{IdentityCredentialError}} given |globalObject|'s <a for="global object">realm</a>
+                and "IdentityCredentialError", and return.
+            1. Let |credential| be a new {{IdentityCredential}} given |globalObject|'s
+                <a for="global object">realm</a>.
+            1. Set |credential|'s {{IdentityCredential/token}} to |token|.
+            1. Set |credential|'s {{IdentityCredential/isAutoSelected}} to
+                |isAutoSelected|.
+        1. Otherwise, i.e. if |json|[|error|] [=map/exists=]:
+            1. If |json|[|error|] is not an [=ordered map=], set |credential| to failure and return.
+            1. [=converted to an IDL value|Convert=] |json| to an {{IdentityCredentialErrorInit}},
+                |errorInit|.
+            1. Let |credential| be a new {{IdentityCredentialError}} given |globalObject|'s
+                <a for="global object">realm</a>, "IdentityCredentialError", and |errorInit|. 
     1. Wait for |credential| to be set.
     1. Return |credential|.
 </div>
@@ -1428,6 +1531,13 @@ An extension may add the following steps after the [=fetch identity assertion/cr
 dictionary IdentityAssertionResponse {
   USVString token;
   USVString continue_on;
+};
+</xmp>
+
+<xmp class="idl">
+dictionary IdentityCredentialErrorInit {
+  DOMString code;
+  DOMString url;
 };
 </xmp>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -531,7 +531,7 @@ When asked to <dfn>attempt to disconnect</dfn> given an {{IdentityCredentialDisc
         |provider| and |globalObject|.
     1. If |config| is failure, [=reject=] |promise| with a "{{NetworkError}}" {{DOMException}}.
     1. Let |disconnectUrl| be the result of [=computing the manifest URL=] given |provider|,
-        |config|.{{IdentityProviderAPIConfig/disconnect_endpoint}}, true, and |globalObject|.
+        |config|.{{IdentityProviderAPIConfig/disconnect_endpoint}}, and |globalObject|.
     1. If |disconnectUrl| is failure, [=reject=] |promise| with a "{{NetworkError}}"
         {{DOMException}}.
     1. [=Send a disconnect request=] with |disconnectUrl|, |options|, and |globalObject|, and let
@@ -648,7 +648,7 @@ Given a |realm|, a {{DOMString}} |message|, and an {{IdentityCredentialErrorInit
     :   <b>{{IdentityCredentialError/error}}</b>
     ::  The {{IdentityCredentialError/error}}'s attribute getter returns the value it is set to.
         It represents the type of error which resulted in an {{IdentityCredential}} not being created.
-        An [=IDP=] MUST not expose sensitive user information in this field, since it is exposed to
+        An [=IDP=] MUST NOT expose sensitive user information in this field, since it is exposed to
         the [=RP=].
     :   <b>{{IdentityCredentialError/url}}</b>
     ::  The {{IdentityCredentialError/url}}'s attribute getter returns the value it is set to.
@@ -810,10 +810,10 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
         algorithm. See <a href="https://github.com/w3c/webappsec-credential-management/issues/210">issue</a>.
 
     1. If |credential| is a pair:
-        1. Let |delayException| be the value of the second element of the pair.
+        1. Let |throwImmediately| be the value of the second element of the pair.
         1. The user agent SHOULD wait a random amount of time
             before the next step if all of the following conditions hold:
-            * |delayException| is true
+            * |throwImmediately| is false
             * The <dfn>promise rejection delay</dfn> was not disabled by
                 [=setdelayenabled|user agent automation=]
             * The user agent has not implemented another way to prevent
@@ -1233,11 +1233,31 @@ or failure.
         1. [=converted to an IDL value|Convert=] |json| to an {{IdentityProviderAPIConfig}} stored
             in |config|.
         1. If one of the previous two steps threw an exception, set |config| to failure.
-        1. Set |config|.{{IdentityProviderAPIConfig/login_url}} to the result of [=computing
-            the manifest URL=] with |provider|, |config|, true, and |globalObject|.
-        1. If |config|.{{IdentityProviderAPIConfig/login_url}} is null, return failure.
-    1. Wait for both |config| and |configInWellKnown| to be set.
-    1. If |configInWellKnown| is true, return |config|. Otherwise, return failure.
+        1. Set |login_url| to the result of [=computing the manifest URL=] with |provider|,
+            |config|.{{IdentityProviderAPIConfig/login_url}}, and |globalObject|.
+        1. Set |accounts_url| to the result of [=computing the manifest URL=] with |provider|,
+            |config|.{{IdentityProviderAPIConfig/accounts_endpoint}}, and |globalObject|.
+        1. If |login_url| or |accounts_url| is failure, set |config| to failure.
+    1. Wait for |config| to be set.
+    1. If |config| is failure, return failure.
+    1. If |skipWellKnown| is true, return |config|.
+    1. Wait for |wellKnown| to be set.
+    1. If |wellKnown| is failure, return failure.
+    1. If |wellKnown|.{{IdentityProviderWellKnown/accounts_endpoint}} and
+        |wellKnown|.{{IdentityProviderWellKnown/login_url}} are set:
+        1. Let |well_known_accounts_url| be the result of [=computing the manifest URL=] with
+            |provider|, |wellKnown|.{{IdentityProviderWellKnown/accounts_endpoint}}, and
+            |globalObject|.
+        1. Let |well_known_login_url| be the result of [=computing the manifest URL=] with |provider|,
+            |wellKnown|.{{IdentityProviderWellKnown/login_url}}, and |globalObject|.
+        1. If |well_known_accounts_url| is not [=url/equal=] to |accounts_url|, return failure.
+        1. If |well_known_login_url| is not [=url/equal=] to |login_url|, return failure.
+    1. Otherwise:
+        1. Let |allowed_config_url| be the result of [=computing the manifest URL=] with |provider|,
+            |wellKnown|.{{IdentityProviderWellKnown/provider_urls}}[0], and |globalObject|.
+        1. If |allowed_config_url| is not [=url/equal=] to |configUrl|, return failure.
+    1. Return |config|.
+
 </div>
 
 NOTE: a two-tier file system is used in order to prevent the [=IDP=] from easily determining the [=RP=]
@@ -1291,7 +1311,7 @@ To <dfn>fetch the accounts</dfn> given an {{IdentityProviderAPIConfig}} |config|
 {{IdentityProviderRequestOptions}} |provider|, and |globalObject|, run the following steps. This
 returns an {{IdentityProviderAccountList}}.
     1. Let |accountsUrl| be the result of [=computing the manifest URL=] given |provider|,
-        |config|["{{IdentityProviderAPIConfig/accounts_endpoint}}"], true, and |globalObject|.
+        |config|["{{IdentityProviderAPIConfig/accounts_endpoint}}"], and |globalObject|.
     1. If |accountsUrl| is failure, return an empty list.
     1. Let |request| be a new <a spec=fetch for=/>request</a> as follows:
 
@@ -1422,7 +1442,7 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
     and |globalObject|, run the following steps. This returns an {{IdentityCredential}} or an
     {{IdentityCredentialError}}.
     1. Let |tokenUrl| be the result of [=computing the manifest URL=] given |provider|,
-        |config|["{{IdentityProviderAPIConfig/id_assertion_endpoint}}"], true, and |globalObject|.
+        |config|["{{IdentityProviderAPIConfig/id_assertion_endpoint}}"], and |globalObject|.
     1. If |tokenUrl| is failure:
         1. [=Queue a global task=] on the [=DOM manipulation task source=] given |globalObject| to
             let |error| be a new {{IdentityCredentialError}} given |globalObject|'s
@@ -1470,29 +1490,22 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
         set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
         1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
             |responseBody|.
-        1. If |json|[|token|] and |json|[|error|] both [=map/exist=] or both do not [=map/exist=],
-            set |credential| to a new {{IdentityCredentialError}} given |globalObject|'s
-            [=global object/realm=] and "IdentityCredentialError", and return.
-        1. If |json|[|token|] [=map/exists=]:
-            1. [=converted to an IDL value|Convert=] |json| to an {{IdentityProviderToken}}, |token|.
-            1. If one of the previous steps threw an exception, set |credential| to a new
-                {{IdentityCredentialError}} given |globalObject|'s [=global object/realm=]
-                and "IdentityCredentialError", and return.
-            1. Let |credential| be a new {{IdentityCredential}} given |globalObject|'s
-                [=global object/realm=].
-            1. Set |credential|'s {{IdentityCredential/token}} to |token|.
-            1. Set |credential|'s {{IdentityCredential/isAutoSelected}} to |isAutoSelected|.
-        1. Otherwise, i.e. if |json|[|error|] [=map/exists=]:
-            1. If |json|[|error|] is not an [=ordered map=], set |credential| to a new
-                {{IdentityCredentialError}} given |globalObject|'s [=global object/realm=] and
-                "IdentityCredentialError", and return.
-            1. [=converted to an IDL value|Convert=] |json| to an {{IdentityCredentialErrorInit}},
-                |errorInit|.
+        1. [=converted to an IDL value|Convert=] |json| to an {{IdentityAssertionResponse}}, |token|.
+        1. If one of the previous two steps threw an exception, set |credential| to a new
+            {{IdentityCredentialError}} given |globalObject|'s [=global object/realm=] and
+            "IdentityCredentialError", and return.
+        1. If {{IdentityAssertionResponse/error}} was specified:
             1. If |errorInit|.{{IdentityCredentialErrorInit/url}} is present:
-                1. Let |errorUrl| be the result of [=computing the manifest URL=] given |provider|,
-                    |errorInit|.{{IdentityCredentialErrorInit/url}}, false, and |globalObject|.
+                1. Let |errorUrl| be the result of running [=parse url=] given
+                    |errorInit|.{{IdentityCredentialErrorInit/url}} (the relative URL),
+                    |globalObject|, and |tokenUrl| (the base URL).
+                1. If |errorUrl|'s [=url/host=]'s [=host/registrable domain=]
+                    is not equal to |tokenUrl|'s, set |errorUrl| to failure.
+                1. If |errorUrl| is not a [=potentially trustworthy URL=], set set |errorUrl| to
+                    failure.
                 1. If |errorUrl| is failure, set |errorInit|.{{IdentityCredentialErrorInit/url}}
-                    to "".
+                    to "". Otherwise, set |errorInit|.{{IdentityCredentialErrorInit/url}} to
+                    |errorUrl|.
             1. Let |credential| be a new {{IdentityCredentialError}} given |globalObject|'s
                 [=global object/realm=], "IdentityCredentialError", and |errorInit|. 
     1. Wait for |credential| to be set.
@@ -1604,7 +1617,7 @@ an {{IdentityProviderRequestOptions}} |provider|, run the following steps. This 
     1. If |config|["{{IdentityProviderAPIConfig/client_metadata_endpoint}}"] is not present, return
         failure.
     1. Let |clientMetadataUrl| be the result of [=computing the manifest URL=] given |provider|,
-        |config|["{{IdentityProviderAPIConfig/client_metadata_endpoint}}"], true, and |globalObject|.
+        |config|["{{IdentityProviderAPIConfig/client_metadata_endpoint}}"], and |globalObject|.
     1. If |clientMetadataUrl| is failure, return failure.
     1. Let |request| be a new <a spec=fetch for=/>request</a> as follows:
 
@@ -1685,8 +1698,8 @@ To <dfn>fetch request</dfn> given a [=/request=] |request|, |globalObject|, and 
 
 <div algorithm>
 When <dfn>computing the manifest URL</dfn> given an {{IdentityProviderConfig}} |provider|, a
-[=string=] |manifestString|, a boolean |requireSameOrigin|, and |globalObject|, perform the following
-steps. This returns a <a spec=url for=/>URL</a> or failure.
+[=string=] |manifestString|, and |globalObject|, perform the following steps. This returns a
+<a spec=url for=/>URL</a> or failure.
     1. Let |configUrl| be the result of running [=parse url=] with |provider|'s
         {{IdentityProviderConfig/configURL}} and |globalObject|.
     1. Let |manifestUrl| be the result of running [=parse url=] given |manifestString| (the relative
@@ -1697,10 +1710,7 @@ steps. This returns a <a spec=url for=/>URL</a> or failure.
         allowed.
 
     1. If |manifestUrl| is failure, return failure.
-    1. If |requireSameOrigin| and |manifestUrl| is not [=same origin=] with |configUrl|, return
-        failure.
-    1. If |requireSameOrigin| is false and |manifestUrl|'s [=url/host=]'s [=host/registrable domain=]
-        is not equal to |configUrl|'s, return failure.
+    1. If |manifestUrl| is not [=same origin=] with |configUrl|, return failure.
     1. If |manifestUrl| is not a [=potentially trustworthy URL=], return failure.
     1. Return |manifestUrl|.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1461,8 +1461,13 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
                     |errorUrl|.
             1. Set |credential| to the result of [=create an IdentityCredentialError=] with
                 |errorInit|, and |globalObject|.
-        1. Otherwise, if |response|'s [=response/status=] is not an [=ok status=], set |credential|
-            to the result of [=create an IdentityCredentialError=] with {} and |globalObject|.
+        1. Otherwise, if |response|'s [=response/status=] is not an [=ok status=]:
+            1. Set |credential| to the result of [=create an IdentityCredentialError=] with {} and
+                |globalObject|.
+            1. The user agent MAY set |credential|'s {{IdentityCredentialError/error}} based on
+                |response|'s [=response/status=]. For example, it could set it to "server_error" if
+                the [=response/status=] is 500 and it could set it to "temporarily_unavailable" if
+                the [=response/status=] is 503.
         1. Otherwise, if {{IdentityAssertionResponse/token}} was specified, let |tokenString|
             be |token|'s {{IdentityAssertionResponse/token}}.
         1. Otherwise, if {{IdentityAssertionResponse/continue_on}} was specified, run these steps
@@ -2339,7 +2344,9 @@ Every {{IdentityAssertionResponse}} is expected to have members with the followi
     ::  A dictionary containing the error that occurred when the ID assertion was fetched.
 </dl>
 
-Only one of `token`, `continue_on`, and `error` should be specified.
+Only one of `token`, `continue_on`, and `error` should be specified. When multiple are specified,
+the order of processing is [`error`, `token`, `continue_on`], so the first present will be used in
+the response.
 
 The content of the {{IdentityAssertionResponse/token}} is opaque to the user agent and can contain
 anything that the [=IDP=] would like to pass to the

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1306,7 +1306,7 @@ To <dfn>fetch the accounts</dfn> given an {{IdentityProviderAPIConfig}} |config|
 {{IdentityProviderRequestOptions}} |provider|, and |globalObject|, run the following steps. This
 returns an {{IdentityProviderAccountList}}.
     1. Let |accountsUrl| be the result of [=computing the manifest URL=] given |provider|,
-        |config|["{{IdentityProviderAPIConfig/accounts_endpoint}}"], and |globalObject|.
+        |config|["{{IdentityProviderAPIConfig/accounts_endpoint}}"], true, and |globalObject|.
     1. If |accountsUrl| is failure, return an empty list.
     1. Let |request| be a new <a spec=fetch for=/>request</a> as follows:
 
@@ -1436,7 +1436,7 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
     {{IdentityProviderRequestOptions}} |provider|, an {{IdentityProviderAPIConfig}} |config|,
     and |globalObject|, run the following steps. This returns an {{IdentityCredential}} or failure.
     1. Let |tokenUrl| be the result of [=computing the manifest URL=] given |provider|,
-        |config|["{{IdentityProviderAPIConfig/id_assertion_endpoint}}"], and |globalObject|.
+        |config|["{{IdentityProviderAPIConfig/id_assertion_endpoint}}"], true, and |globalObject|.
     1. If |tokenUrl| is failure:
         1. [=Queue a global task=] on the [=DOM manipulation task source=] given |globalObject| to
             let |error| be a new {{IdentityCredentialError}} given |globalObject|'s
@@ -1503,6 +1503,11 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
                 "IdentityCredentialError" and return.
             1. [=converted to an IDL value|Convert=] |json| to an {{IdentityCredentialErrorInit}},
                 |errorInit|.
+            1. If |errorInit|.{{IdentityCredentialErrorInit/url}} is present:
+                1. Let |errorUrl| be the result of [=computing the manifest URL=] given |provider|,
+                    |errorInit|.{{IdentityCredentialErrorInit/url}}, false, and |globalObject|.
+                1. If |errorUrl| is failure, set |errorInit|.{{IdentityCredentialErrorInit/url}}
+                    to "".
             1. Let |credential| be a new {{IdentityCredentialError}} given |globalObject|'s
                 [=global object/realm=], "IdentityCredentialError", and |errorInit|. 
     1. Wait for |credential| to be set.
@@ -1614,7 +1619,7 @@ an {{IdentityProviderRequestOptions}} |provider|, run the following steps. This 
     1. If |config|["{{IdentityProviderAPIConfig/client_metadata_endpoint}}"] is not present, return
         failure.
     1. Let |clientMetadataUrl| be the result of [=computing the manifest URL=] given |provider|,
-        |config|["{{IdentityProviderAPIConfig/client_metadata_endpoint}}"], and |globalObject|.
+        |config|["{{IdentityProviderAPIConfig/client_metadata_endpoint}}"], true, and |globalObject|.
     1. If |clientMetadataUrl| is failure, return failure.
     1. Let |request| be a new <a spec=fetch for=/>request</a> as follows:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -634,6 +634,19 @@ dictionary IdentityCredentialErrorInit {
   };
 </pre>
 
+<div algorithm="create an IdentityCredentialError">
+To <dfn>create an IdentityCredentialError</dfn> given an {{IdentityCredentialErrorInit}} |options|
+and a |globalObject|, run the following steps:
+    1. Let |error| be a [=new=] {{IdentityCredentialError}} with |globalObject|'s
+        [=relevant realm=].
+    1. Set |error|'s {{DOMException/message}} to "IdentityCredentialError".
+    1. Set |error|.{{IdentityCredentialError/error}} to |options|.{{IdentityCredentialError/error}}
+        if it is present in |options|, or to "" otherwise.
+    1. Set |error|.{{IdentityCredentialError/url}} to |options|.{{IdentityCredentialError/url}}
+        if it is present in |options|, or to "" otherwise.
+    1. Return |error|.
+</div>
+
 <div algorithm="IdentityCredentialError constructor">
 Given a |realm|, a {{DOMString}} |message|, and an {{IdentityCredentialErrorInit}} |options|, the
 {{IdentityCredentialError/constructor()}} must run the following steps:
@@ -844,8 +857,8 @@ returned to the [=RP=].
 To <dfn>create an IdentityCredential</dfn> given an {{IdentityProviderRequestOptions}}
 |provider|, a {{CredentialRequestOptions}} |options|, and a
 |globalObject|, run the following steps. This returns an {{IdentityCredential}}, an
-{{IdentityCredentialError}}, or a pair (failure, bool), where the bool indicates whether to delay
-throwing the exception.
+{{IdentityCredentialError}}, or a pair (failure, bool), where the bool indicates whether to throw
+the exception immediately.
     1. Assert: These steps are running [=in parallel=].
     1. Let |mode| be |options|'s {{IdentityCredentialRequestOptions/mode}}.
     1. If |mode| is {{IdentityCredentialRequestOptionsMode/active}}:
@@ -1013,8 +1026,8 @@ throwing the exception.
     1. If |credential| is an {{IdentityCredentialError}}:
         1. The [=user agent=] MUST show UI to the user indicating that the identity assertion fetch
             has failed.
-        1. The [=user agent=] MAY use the {{IdentityCredentialError/error}} in its UI to provide a
-            more specific error message to the user. For instance, if the value is one of
+        1. The [=user agent=] SHOULD use the {{IdentityCredentialError/error}} in its UI to provide
+            a more specific error message to the user. For instance, if the value is one of
             "invalid_request", "unauthorized_client", "access_denied", "server_error", and
             "temporarily_unavailable", the [=user agent=] may note the reason in a user-friendly
             manner. See [here](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) for
@@ -1383,8 +1396,8 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
         |config|["{{IdentityProviderAPIConfig/id_assertion_endpoint}}"], and |globalObject|.
     1. If |tokenUrl| is failure:
         1. [=Queue a global task=] on the [=DOM manipulation task source=] given |globalObject| to
-            let |error| be a new {{IdentityCredentialError}} given |globalObject|'s
-            [=global object/realm=].
+            let |error| be the result of [=create an IdentityCredentialError=] given {} and
+            |globalObject|.
         1. Wait for |error| to be set, and return it.
     1. Let |requestBody| be the result of running [=urlencoded serializer=] with a list containing:
         1. ("client_id", |provider|'s {{IdentityProviderConfig/clientId}})
@@ -1429,9 +1442,8 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
         1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
             |responseBody|.
         1. [=converted to an IDL value|Convert=] |json| to an {{IdentityAssertionResponse}}, |token|.
-        1. If one of the previous two steps threw an exception, set |credential| to a new
-            {{IdentityCredentialError}} given |globalObject|'s [=global object/realm=] and
-            "IdentityCredentialError", and return.
+        1. If one of the previous two steps threw an exception, set |credential| to the result of
+            [=create an IdentityCredentialError=] with {} and |globalObject|.
         1. If {{IdentityAssertionResponse/error}} was specified:
             1. If |errorInit|.{{IdentityCredentialErrorInit/url}} is present:
                 1. Let |errorUrl| be the result of running [=parse url=] given
@@ -1444,8 +1456,36 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
                 1. If |errorUrl| is failure, set |errorInit|.{{IdentityCredentialErrorInit/url}}
                     to "". Otherwise, set |errorInit|.{{IdentityCredentialErrorInit/url}} to
                     |errorUrl|.
-            1. Let |credential| be a new {{IdentityCredentialError}} given |globalObject|'s
-                [=global object/realm=], "IdentityCredentialError", and |errorInit|. 
+            1. Set |credential| to the result of [=create an IdentityCredentialError=] with
+                |errorInit|, and |globalObject|.
+        1. Otherwise, if {{IdentityAssertionResponse/token}} was specified, let |tokenString|
+            be |token|'s {{IdentityAssertionResponse/token}}.
+        1.  Otherwise, if {{IdentityAssertionResponse/continue_on}} was specified, run these steps
+            [=in parallel=]:
+            1. Let |continueOnUrl| be the result of running [=parse url=] with |token|'s
+                {{IdentityAssertionResponse/continue_on}} and |globalObject|.
+            1. If |continueOnUrl| is failure, set |credential| to failure and return.
+            1. If |continueOnUrl| is not [=same origin=] with |tokenUrl|, set |credential|
+                to failure and return.
+            1. Let |tokenPair| be the result of [=show a continuation dialog=] with |continueOnUrl|.
+            1. If |tokenPair| is failure, set |credential| to failure and return.
+            1. Let |tokenString| be the first entry of |tokenPair|.
+            1. If the second entry of |tokenPair| is not null, set |accountId| to that second entry.
+        1. Otherwise, set |credential| to a the result of [=create an IdentityCredentialError=] with
+            |errorInit| and |globalObject|,
+        1. Wait for |tokenString| or |credential| to be set.
+        1. If |credential| is set:
+            1. Assert that |credential| is set to failure.
+            1. Return |credential|.
+        1. [=Create a connection between the RP and the IdP account=] with |provider|, |accountId|, and
+            |globalObject|.
+        1. Let |credential| be a new {{IdentityCredential}} given |globalObject|'s
+            <a for="global object">realm</a>.
+        1. Set |credential|'s {{IdentityCredential/token}} to |tokenString|.
+        1. Set |credential|'s {{IdentityCredential/isAutoSelected}} to
+            |isAutoSelected|.
+        1. Set |credential|'s {{IdentityCredential/configURL}} to |provider|'s
+            {{IdentityProviderConfig/configURL}}.
     1. Wait for |credential| to be set.
     1. Return |credential|.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1694,9 +1694,9 @@ To <dfn>fetch request</dfn> given a [=/request=] |request|, |globalObject|, and 
 </div>
 
 <div algorithm>
-When <dfn>computing the manifest URL</dfn> given an {{IdentityProviderRequestOptions}} |provider|, a
-[=string=] |manifestString|, and |globalObject|, perform the following steps. This returns a
-<a spec=url for=/>URL</a> or failure.
+When <dfn>computing the manifest URL</dfn> given an {{IdentityProviderConfig}} |provider|, a
+[=string=] |manifestString|, a boolean |requireSameOrigin|, and |globalObject|, perform the
+following steps. This returns a <a spec=url for=/>URL</a> or failure.
     1. Let |configUrl| be the result of running [=parse url=] with |provider|'s
         {{IdentityProviderConfig/configURL}} and |globalObject|.
     1. Let |manifestUrl| be the result of running [=parse url=] given |manifestString| (the relative
@@ -1707,7 +1707,10 @@ When <dfn>computing the manifest URL</dfn> given an {{IdentityProviderRequestOpt
         allowed.
 
     1. If |manifestUrl| is failure, return failure.
-    1. If |manifestUrl| is not [=same origin=] with |configUrl|, return failure.
+    1. If |requireSameOrigin| and |manifestUrl| is not [=same origin=] with |configUrl|, return
+        failure.
+    1. If |requireSameOrigin| is false and |manifestUrl|'s <a spec=url>domain</a> is not equal to
+        |configUrl|'s, return failure.
     1. If |manifestUrl| is not a [=potentially trustworthy URL=], return failure.
     1. Return |manifestUrl|.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -856,8 +856,9 @@ thrown to the [=RP=].
 <div algorithm="create an IdentityCredential">
 To <dfn>create an IdentityCredential</dfn> given a [=sequence=] of
 {{IdentityProviderRequestOptions}} |providerList|, a {{CredentialRequestOptions}} |options|, and a
-|globalObject|, run the following steps. This returns an {{IdentityCredential}} or a pair (failure,
-bool), where the bool indicates whether to throw the exception immediately.
+|globalObject|, run the following steps. This returns an {{IdentityCredential}}, an
+{{IdentityCredentialError}}, or a pair (failure, bool), where the bool indicates whether to throw
+the exception immediately.
     1. Assert: These steps are running [=in parallel=].
     1. Let |mode| be |options|'s {{IdentityCredentialRequestOptions/mode}}.
     1. If |mode| is {{IdentityCredentialRequestOptionsMode/active}}:
@@ -1439,11 +1440,13 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
     1. Let |credential| be null.
     1. [=Fetch request=] with |request| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
         set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
+        1. If |responseBody| is null or failure, set |credential| to the result of
+            [=create an IdentityCredentialError=] with {} and |globalObject|, and return.
         1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
             |responseBody|.
         1. [=converted to an IDL value|Convert=] |json| to an {{IdentityAssertionResponse}}, |token|.
         1. If one of the previous two steps threw an exception, set |credential| to the result of
-            [=create an IdentityCredentialError=] with {} and |globalObject|.
+            [=create an IdentityCredentialError=] with {} and |globalObject|, and return.
         1. If {{IdentityAssertionResponse/error}} was specified, let |errorInit| be the value and:
             1. If |errorInit|.{{IdentityCredentialErrorInit/url}} is present:
                 1. Let |errorUrl| be the result of running [=parse url=] given

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -531,7 +531,7 @@ When asked to <dfn>attempt to disconnect</dfn> given an {{IdentityCredentialDisc
         |provider| and |globalObject|.
     1. If |config| is failure, [=reject=] |promise| with a "{{NetworkError}}" {{DOMException}}.
     1. Let |disconnectUrl| be the result of [=computing the manifest URL=] given |provider|,
-        |config|.{{IdentityProviderAPIConfig/disconnect_endpoint}}, and |globalObject|.
+        |config|.{{IdentityProviderAPIConfig/disconnect_endpoint}}, true, and |globalObject|.
     1. If |disconnectUrl| is failure, [=reject=] |promise| with a "{{NetworkError}}"
         {{DOMException}}.
     1. [=Send a disconnect request=] with |disconnectUrl|, |options|, and |globalObject|, and let
@@ -1703,8 +1703,8 @@ To <dfn>fetch request</dfn> given a [=/request=] |request|, |globalObject|, and 
 
 <div algorithm>
 When <dfn>computing the manifest URL</dfn> given an {{IdentityProviderConfig}} |provider|, a
-[=string=] |manifestString|, and |globalObject|, perform the following steps. This returns a
-<a spec=url for=/>URL</a> or failure.
+[=string=] |manifestString|, a boolean |requireSameOrigin|, and |globalObject|, perform the following
+steps. This returns a <a spec=url for=/>URL</a> or failure.
     1. Let |configUrl| be the result of running [=parse url=] with |provider|'s
         {{IdentityProviderConfig/configURL}} and |globalObject|.
     1. Let |manifestUrl| be the result of running [=parse url=] given |manifestString| (the relative
@@ -1715,7 +1715,10 @@ When <dfn>computing the manifest URL</dfn> given an {{IdentityProviderConfig}} |
         allowed.
 
     1. If |manifestUrl| is failure, return failure.
-    1. If |manifestUrl| is not [=same origin=] with |configUrl|, return failure.
+    1. If |requireSameOrigin| and |manifestUrl| is not [=same origin=] with |configUrl|, return
+        failure.
+    1. If |requireSameOrigin| is false and |manifestUrl|'s [=url/host=]'s [=host/registrable domain=]
+        is not equal to |configUrl|'s, return failure.
     1. If |manifestUrl| is not a [=potentially trustworthy URL=], return failure.
     1. Return |manifestUrl|.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -618,9 +618,16 @@ This specification introduces a new type of {{DOMException}}, the {{IdentityCred
 is used when the [=user agent=] does not receive an identity assertion after the user has requested
 to use a federated account.
 
+<xmp class="idl">
+dictionary IdentityCredentialErrorInit {
+  DOMString code;
+  DOMString url;
+};
+</xmp>
+
 <pre class="idl">
   [Exposed=Window, SecureContext]
-  interface IdentityCredentialError: DOMException {
+  interface IdentityCredentialError : DOMException {
     constructor(optional DOMString message = "", optional IdentityCredentialErrorInit options = {});
     readonly attribute DOMString code;
     readonly attribute DOMString url;
@@ -1433,7 +1440,7 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
     1. If |tokenUrl| is failure:
         1. [=Queue a global task=] on the [=DOM manipulation task source=] given |globalObject| to
             let |error| be a new {{IdentityCredentialError}} given |globalObject|'s
-            <a for="global object">realm</a>.
+            [=global object/realm=].
         1. Wait for |error| to be set, and return it.
     1. Let |requestBody| be the result of running [=urlencoded serializer=] with a list containing:
         1. ("client_id", |provider|'s {{IdentityProviderConfig/clientId}})
@@ -1479,23 +1486,25 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
             |responseBody|.
         1. If |json|[|token|] and |json|[|error|] both [=map/exist=] or both do not [=map/exist=],
             set |credential| to a new {{IdentityCredentialError}} given |globalObject|'s
-            <a for="global object">realm</a> and "IdentityCredentialError", and return.
+            [=global object/realm=] and "IdentityCredentialError", and return.
         1. If |json|[|token|] [=map/exists=]:
             1. [=converted to an IDL value|Convert=] |json| to an {{IdentityProviderToken}}, |token|.
             1. If one of the previous steps threw an exception, set |credential| to a new
-                {{IdentityCredentialError}} given |globalObject|'s <a for="global object">realm</a>
+                {{IdentityCredentialError}} given |globalObject|'s [=global object/realm=]
                 and "IdentityCredentialError", and return.
             1. Let |credential| be a new {{IdentityCredential}} given |globalObject|'s
-                <a for="global object">realm</a>.
+                [=global object/realm=].
             1. Set |credential|'s {{IdentityCredential/token}} to |token|.
             1. Set |credential|'s {{IdentityCredential/isAutoSelected}} to
                 |isAutoSelected|.
         1. Otherwise, i.e. if |json|[|error|] [=map/exists=]:
-            1. If |json|[|error|] is not an [=ordered map=], set |credential| to failure and return.
+            1. If |json|[|error|] is not an [=ordered map=], set |credential| to a new
+                {{IdentityCredentialError}} given |globalObject|'s [=global object/realm=] and
+                "IdentityCredentialError" and return.
             1. [=converted to an IDL value|Convert=] |json| to an {{IdentityCredentialErrorInit}},
                 |errorInit|.
             1. Let |credential| be a new {{IdentityCredentialError}} given |globalObject|'s
-                <a for="global object">realm</a>, "IdentityCredentialError", and |errorInit|. 
+                [=global object/realm=], "IdentityCredentialError", and |errorInit|. 
     1. Wait for |credential| to be set.
     1. Return |credential|.
 </div>
@@ -1533,13 +1542,6 @@ An extension may add the following steps after the [=fetch identity assertion/cr
 dictionary IdentityAssertionResponse {
   USVString token;
   USVString continue_on;
-};
-</xmp>
-
-<xmp class="idl">
-dictionary IdentityCredentialErrorInit {
-  DOMString code;
-  DOMString url;
 };
 </xmp>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -826,7 +826,7 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
                 However, UAs may have different UI approaches here and prevent it in a different way.
         1. [=Queue a global task=] on the [=DOM manipulation task source=]
             to throw a new "{{NetworkError}}" {{DOMException}}.
-    1. Else, return |credential| (this may throw, since it may be an
+    1. Otherwise, return |credential| (this may throw, since it may be an
         {{IdentityCredentialError}}).
 </div>
 
@@ -1033,20 +1033,19 @@ throwing the exception.
         <dl class=switch>
         <dt>If |mediation| is not "{{CredentialMediationRequirement/required}}", |requiresUserMediation|
         is false, and |numRegisteredAccounts| is equal to 1:</dt>
-            1. Set |account| to |registeredAccount| and |accountState| to the result of running
-                [=compute the connection status=] algorithm given |provider| and |account|. When doing this,
-                the user agent MAY show some UI to the user indicating that they are being
+            1. Set |account| to |registeredAccount|, |permission| to true, and |isAutoSelected| to true.
+                When doing this, the user agent MAY show some UI to the user indicating that they are being
                 <dfn>auto-reauthenticated</dfn>.
-            1. Set |isAutoSelected| to true.
         <dt>If |mediation| is "{{CredentialMediationRequirement/silent}}":</dt>
             1. Return (failure, false).
         <dt> If |accountsList|'s size is 1:</dt>
             1. Set |account| to |accountsList|[0].
-            1. Set |accountState| to the result of running the [=compute the connection status=] algorithm
-                given |provider|, |account|, and |globalObject|.
-            1. If |accountState| is [=compute the connection status/disconnected=],
-                let |permission| be the result of running [=request permission to sign-up=] algorithm
-                with |account|, |accountState|, |config|, |provider|, and |globalObject|. Also set
+            1. If [=compute the connection status=] of |account|, |provider| and |globalObject| returns
+                [=compute the connection status/connected=], show a dialog to request user permission to sign
+                in via |account|, and set the result in |permission|. The user agent MAY use |options|'s
+                {{IdentityCredentialRequestOptions/context}} to customize the dialog.
+            1. Otherwise, let |permission| be the result of running [=request permission to sign-up=]
+                algorithm with |account|, |config|, |provider|, and |globalObject|. Also set
                 |disclosureTextShown| to true.
             1. Otherwise, show a dialog to request user permission to sign in via |account|, and set the
                 result in |permission|. The user agent MAY use |options|'s
@@ -1704,8 +1703,8 @@ To <dfn>fetch request</dfn> given a [=/request=] |request|, |globalObject|, and 
 
 <div algorithm>
 When <dfn>computing the manifest URL</dfn> given an {{IdentityProviderConfig}} |provider|, a
-[=string=] |manifestString|, a boolean |requireSameOrigin|, and |globalObject|, perform the
-following steps. This returns a <a spec=url for=/>URL</a> or failure.
+[=string=] |manifestString|, and |globalObject|, perform the following steps. This returns a
+<a spec=url for=/>URL</a> or failure.
     1. Let |configUrl| be the result of running [=parse url=] with |provider|'s
         {{IdentityProviderConfig/configURL}} and |globalObject|.
     1. Let |manifestUrl| be the result of running [=parse url=] given |manifestString| (the relative
@@ -1716,10 +1715,7 @@ following steps. This returns a <a spec=url for=/>URL</a> or failure.
         allowed.
 
     1. If |manifestUrl| is failure, return failure.
-    1. If |requireSameOrigin| and |manifestUrl| is not [=same origin=] with |configUrl|, return
-        failure.
-    1. If |requireSameOrigin| is false and |manifestUrl|'s [=url/host=]'s [=host/registrable domain=]
-        is not equal to |configUrl|'s, return failure.
+    1. If |manifestUrl| is not [=same origin=] with |configUrl|, return failure.
     1. If |manifestUrl| is not a [=potentially trustworthy URL=], return failure.
     1. Return |manifestUrl|.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1035,7 +1035,7 @@ the exception immediately.
         1. The [=user agent=] MAY use the {{IdentityCredentialError/url}} to display a hyperlink
             in its UI so the user can click on it to learn more information about the error message.
         1. Wait until the UI is acknowledged or dismissed by the user.
-        
+
           Note: this wait means the [=user agent=] rejects the call only after the UI has been
               closed by the user.
     1. Return |credential|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -615,8 +615,8 @@ dictionary DisconnectedAccount {
 <!-- ============================================================ -->
 
 This specification introduces a new type of {{DOMException}}, the {{IdentityCredentialError}}. It
-is used when the [=IDP=] cannot create an {{IdentityCredential}} after the user has requested to use
-a federated account.
+is used when the [=user agent=] does not receive an identity assertion after the user has requested
+to use a federated account.
 
 <pre class="idl">
   [Exposed=Window, SecureContext]
@@ -631,8 +631,10 @@ a federated account.
 The {{IdentityCredentialError/constructor()}}, given a |realm|, a {{DOMString}} |message| and a
     {{IdentityCredentialErrorInit}} |options| must run the following steps:
     1. Invoke the {{DOMException}}'s {{DOMException/constructor()}}, passing |realm| and |message|.
-    1. Set <a>this</a>.{{IdentityCredentialError/code}} to |options|.{{IdentityCredentialError/code}}.
-    1. Set <a>this</a>.{{IdentityCredentialError/url}} to |options.{{IdentityCredentialError/url}}.
+    1. Set <a>this</a>.{{IdentityCredentialError/code}} to |options|.{{IdentityCredentialError/code}}
+        if it is present in |options|, or to "" otherwise.
+    1. Set <a>this</a>.{{IdentityCredentialError/url}} to |options|.{{IdentityCredentialError/url}}
+        if it is present in |options|, or to "" otherwise.
 </div>
 
 <dl>
@@ -1072,7 +1074,7 @@ throwing the exception.
         1. Wait until the UI is acknowledged or dismissed by the user.
         
         Note: this wait means the [=user agent=] rejects the call only after the UI has been
-            dismissed by the user.
+            closed by the user.
     1. Return |credential|.
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -618,12 +618,12 @@ This specification introduces a new type of {{DOMException}}, the {{IdentityCred
 is used when the [=user agent=] does not receive an identity assertion after the user has requested
 to use a federated account.
 
-<xmp class="idl">
+<pre class="idl">
 dictionary IdentityCredentialErrorInit {
   DOMString error;
   DOMString url;
 };
-</xmp>
+</pre>
 
 <pre class="idl">
   [Exposed=Window, SecureContext]
@@ -850,15 +850,14 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
 <!-- ============================================================ -->
 
 The <a>create an IdentityCredential</a> algorithm invokes the various FedCM fetches, shows the user
-agent UI, and creates the {{IdentityCredential}} or {{IdentityCredentialError}} which is then
-returned to the [=RP=].
+agent UI, and creates the {{IdentityCredential}} or throws an exception which is then returned or
+thrown to the [=RP=].
 
 <div algorithm="create an IdentityCredential">
-To <dfn>create an IdentityCredential</dfn> given an {{IdentityProviderRequestOptions}}
-|provider|, a {{CredentialRequestOptions}} |options|, and a
-|globalObject|, run the following steps. This returns an {{IdentityCredential}}, an
-{{IdentityCredentialError}}, or a pair (failure, bool), where the bool indicates whether to throw
-the exception immediately.
+To <dfn>create an IdentityCredential</dfn> given a [=sequence=] of
+{{IdentityProviderRequestOptions}} |providerList|, a {{CredentialRequestOptions}} |options|, and a
+|globalObject|, run the following steps. This returns an {{IdentityCredential}} or a pair (failure,
+bool), where the bool indicates whether to throw the exception immediately.
     1. Assert: These steps are running [=in parallel=].
     1. Let |mode| be |options|'s {{IdentityCredentialRequestOptions/mode}}.
     1. If |mode| is {{IdentityCredentialRequestOptionsMode/active}}:
@@ -1399,7 +1398,8 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
             let |error| be the result of [=create an IdentityCredentialError=] given {} and
             |globalObject|.
         1. Wait for |error| to be set, and return it.
-    1. Let |requestBody| be the result of running [=urlencoded serializer=] with a list containing:
+    1. <dfn for="fetch identity assertion">Create a list</dfn>: let |list| be a list with the
+        following entries:
         1. ("client_id", |provider|'s {{IdentityProviderConfig/clientId}})
         1. ("nonce", |provider|'s {{IdentityProviderRequestOptions/nonce}})
         1. ("account_id",  |accountId|)
@@ -1444,7 +1444,7 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
         1. [=converted to an IDL value|Convert=] |json| to an {{IdentityAssertionResponse}}, |token|.
         1. If one of the previous two steps threw an exception, set |credential| to the result of
             [=create an IdentityCredentialError=] with {} and |globalObject|.
-        1. If {{IdentityAssertionResponse/error}} was specified:
+        1. If {{IdentityAssertionResponse/error}} was specified, let |errorInit| be the value and:
             1. If |errorInit|.{{IdentityCredentialErrorInit/url}} is present:
                 1. Let |errorUrl| be the result of running [=parse url=] given
                     |errorInit|.{{IdentityCredentialErrorInit/url}} (the relative URL),
@@ -1460,7 +1460,7 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
                 |errorInit|, and |globalObject|.
         1. Otherwise, if {{IdentityAssertionResponse/token}} was specified, let |tokenString|
             be |token|'s {{IdentityAssertionResponse/token}}.
-        1.  Otherwise, if {{IdentityAssertionResponse/continue_on}} was specified, run these steps
+        1. Otherwise, if {{IdentityAssertionResponse/continue_on}} was specified, run these steps
             [=in parallel=]:
             1. Let |continueOnUrl| be the result of running [=parse url=] with |token|'s
                 {{IdentityAssertionResponse/continue_on}} and |globalObject|.
@@ -1472,7 +1472,7 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
             1. Let |tokenString| be the first entry of |tokenPair|.
             1. If the second entry of |tokenPair| is not null, set |accountId| to that second entry.
         1. Otherwise, set |credential| to a the result of [=create an IdentityCredentialError=] with
-            |errorInit| and |globalObject|,
+            {} and |globalObject|,
         1. Wait for |tokenString| or |credential| to be set.
         1. If |credential| is set:
             1. Assert that |credential| is set to failure.
@@ -1519,12 +1519,13 @@ An extension may add the following steps after the [=fetch identity assertion/cr
             instead check `disclosure_shown_for`.
 </div>
 
-<xmp class="idl">
+<pre class="idl">
 dictionary IdentityAssertionResponse {
   USVString token;
   USVString continue_on;
+  IdentityCredentialErrorInit error;
 };
-</xmp>
+</pre>
 
 <!-- ============================================================ -->
 ### Extension: Request permission to sign-up ### {#request-permission-signup}
@@ -2329,9 +2330,11 @@ Every {{IdentityAssertionResponse}} is expected to have members with the followi
     ::  The resulting token.
     :   <dfn>continue_on</dfn>
     ::  A URL that the user agent will open in a popup to finish the authentication process.
+    :   <dfn>error</dfn>
+    ::  A dictionary containing the error that occurred when the ID assertion was fetched.
 </dl>
 
-Only one of `token` and `continue_on` should be specified.
+Only one of `token`, `continue_on`, and `error` should be specified.
 
 The content of the {{IdentityAssertionResponse/token}} is opaque to the user agent and can contain
 anything that the [=IDP=] would like to pass to the

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1434,7 +1434,8 @@ the token or error that will be provided to the [=RP=].
 To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
     |accountId|, a boolean <var ignore="">permissionRequested</var>, a boolean |isAutoSelected|, an
     {{IdentityProviderRequestOptions}} |provider|, an {{IdentityProviderAPIConfig}} |config|,
-    and |globalObject|, run the following steps. This returns an {{IdentityCredential}} or failure.
+    and |globalObject|, run the following steps. This returns an {{IdentityCredential}} or an
+    {{IdentityCredentialError}}.
     1. Let |tokenUrl| be the result of [=computing the manifest URL=] given |provider|,
         |config|["{{IdentityProviderAPIConfig/id_assertion_endpoint}}"], true, and |globalObject|.
     1. If |tokenUrl| is failure:
@@ -1495,8 +1496,7 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
             1. Let |credential| be a new {{IdentityCredential}} given |globalObject|'s
                 [=global object/realm=].
             1. Set |credential|'s {{IdentityCredential/token}} to |token|.
-            1. Set |credential|'s {{IdentityCredential/isAutoSelected}} to
-                |isAutoSelected|.
+            1. Set |credential|'s {{IdentityCredential/isAutoSelected}} to |isAutoSelected|.
         1. Otherwise, i.e. if |json|[|error|] [=map/exists=]:
             1. If |json|[|error|] is not an [=ordered map=], set |credential| to a new
                 {{IdentityCredentialError}} given |globalObject|'s [=global object/realm=] and

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -609,6 +609,38 @@ dictionary DisconnectedAccount {
   required USVString account_id;
 };
 </xmp>
+## The IdentityCredentialError Interface ## {#browser-api-identity-credential-error-interface}
+<!-- ============================================================ -->
+
+This specification introduces a new type of {{DOMException}}, the {{IdentityCredentialError}}. It
+is used when the [=IDP=] cannot create an {{IdentityCredential}} after the user has requested to use
+a federated account.
+
+<pre class="idl">
+  [Exposed=Window, SecureContext]
+  interface IdentityCredentialError: DOMException {
+    constructor(optional DOMString message = "", IdentityCredentialErrorInit options);
+    readonly attribute DOMString code;
+    readonly attribute DOMString url;
+  };
+</pre>
+
+<div algorithm="IdentityCredentialError constructor">
+The {{IdentityCredentialError/constructor()}}, given a |realm|, a {{DOMString}} |message| and a
+    {{IdentityCredentialErrorInit}} |options| must run the following steps:
+    1. Invoke the {{DOMException}}'s {{DOMException/constructor()}}, passing |realm| and |message|.
+    1. Set <a>this</a>.{{IdentityCredentialError/code}} to |options|.{{IdentityCredentialError/code}}.
+    1. Set <a>this</a>.{{IdentityCredentialError/url}} to |options.{{IdentityCredentialError/url}}.
+</div>
+
+<dl>
+    :   <b>{{IdentityCredentialError/code}}</b>
+    ::  The {{IdentityCredentialError/code}}'s attribute getter returns the value it is set to.
+        It represents the type of error which resulted in an {{IdentityCredential}} not being created.
+    :   <b>{{IdentityCredentialError/url}}</b>
+    ::  The {{IdentityCredentialError/url}}'s attribute getter returns the value it is set to.
+        It represents a URL where the user can learn more information about the error.
+</dl>
 
 <!-- ============================================================ -->
 ## The IdentityCredentialError Interface ## {#browser-api-identity-credential-error-interface}
@@ -1547,6 +1579,13 @@ An extension may add the following steps after the [=fetch identity assertion/cr
 dictionary IdentityAssertionResponse {
   USVString token;
   USVString continue_on;
+};
+</xmp>
+
+<xmp class="idl">
+dictionary IdentityCredentialErrorInit {
+  DOMString code;
+  DOMString url;
 };
 </xmp>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -621,7 +621,7 @@ a federated account.
 <pre class="idl">
   [Exposed=Window, SecureContext]
   interface IdentityCredentialError: DOMException {
-    constructor(optional DOMString message = "", IdentityCredentialErrorInit options);
+    constructor(optional DOMString message = "", optional IdentityCredentialErrorInit options = {});
     readonly attribute DOMString code;
     readonly attribute DOMString url;
   };
@@ -645,7 +645,7 @@ The {{IdentityCredentialError/constructor()}}, given a |realm|, a {{DOMString}} 
 </dl>
 
 <!-- ============================================================ -->
-### The CredentialRequestOptions ### {#browser-api-credential-request-options}
+## The CredentialRequestOptions ## {#browser-api-credential-request-options}
 <!-- ============================================================ -->
 
 This section defines the dictionaries passed into the JavaScript call:
@@ -741,7 +741,7 @@ dictionary IdentityProviderRequestOptions : IdentityProviderConfig {
 </dl>
 
 <!-- ============================================================ -->
-### The <code>\[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)</code> internal method ### {#browser-api-rp-sign-in}
+## The <code>\[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)</code> internal method ## {#browser-api-rp-sign-in}
 <!-- ============================================================ -->
 
 The {{Credential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1029,36 +1029,40 @@ throwing the exception.
         1. If |accState| is [=compute the connection status/connected=], set |registeredAccount| to
             |acc| and increase |numRegisteredAccounts| by 1.
     1. Let |permission|, |disclosureTextShown|, and |isAutoSelected| be set to false.
-    1. If |mediation| is not "{{CredentialMediationRequirement/required}}", |requiresUserMediation|
-        is false, and |numRegisteredAccounts| is equal to 1:
-        1. Set |account| to |registeredAccount| and |accountState| to the result of running
-            [=compute the connection status=] algorithm given |provider| and |account|. When doing this,
-            the user agent MAY show some UI to the user indicating that they are being
-            <dfn>auto-reauthenticated</dfn>.
-        1. Set |isAutoSelected| to true.
-    1. Else if |mediation| is "{{CredentialMediationRequirement/silent}}", return (failure, false).
-    1. Else if |accountsList|'s size is 1:
-        1. Set |account| to |accountsList|[0].
-        1. Set |accountState| to the result of running the [=compute the connection status=] algorithm
-            given |provider|, |account|, and |globalObject|.
-        1. If |accountState| is [=compute the connection status/disconnected=],
-            let |permission| be the result of running [=request permission to sign-up=] algorithm
-            with |account|, |accountState|, |config|, |provider|, and |globalObject|. Also set
-            |disclosureTextShown| to true.
-        1. Else, show a dialog to request user permission to sign in via |account|, and set the
-            result in |permission|. The user agent MAY use |options|'s
-            {{IdentityCredentialRequestOptions/context}} to customize the dialog.
-    1. Else:
-        1. Set |account| to the result of running the [=select an account=] from the
-            |accountsList|.
-        1. If |account| is failure, return (failure, true).
-        1. Set |accountState| to the result of running the [=compute the connection status=] algorithm
-            given |provider| and |account|.
-        1. If |accountState| is [=compute the connection status/disconnected=]:
-            1. Let |permission| be the result of running the [=request permission to sign-up=]
-                algorithm with |account|, |config|, |provider|, and |globalObject|.
-            1. Set |disclosureTextShown| to true.
-        1. Else, set |permission| to true.
+    1. Perform the set of instructions corresponding to the first matching statement:
+        <dl class=switch>
+        <dt>If |mediation| is not "{{CredentialMediationRequirement/required}}", |requiresUserMediation|
+        is false, and |numRegisteredAccounts| is equal to 1:</dt>
+            1. Set |account| to |registeredAccount| and |accountState| to the result of running
+                [=compute the connection status=] algorithm given |provider| and |account|. When doing this,
+                the user agent MAY show some UI to the user indicating that they are being
+                <dfn>auto-reauthenticated</dfn>.
+            1. Set |isAutoSelected| to true.
+        <dt>If |mediation| is "{{CredentialMediationRequirement/silent}}":</dt>
+            1. Return (failure, false).
+        <dt> If |accountsList|'s size is 1:</dt>
+            1. Set |account| to |accountsList|[0].
+            1. Set |accountState| to the result of running the [=compute the connection status=] algorithm
+                given |provider|, |account|, and |globalObject|.
+            1. If |accountState| is [=compute the connection status/disconnected=],
+                let |permission| be the result of running [=request permission to sign-up=] algorithm
+                with |account|, |accountState|, |config|, |provider|, and |globalObject|. Also set
+                |disclosureTextShown| to true.
+            1. Otherwise, show a dialog to request user permission to sign in via |account|, and set the
+                result in |permission|. The user agent MAY use |options|'s
+                {{IdentityCredentialRequestOptions/context}} to customize the dialog.
+        <dt>Otherwise:</dt>
+            1. Set |account| to the result of running the [=select an account=] from the
+                |accountsList|.
+            1. If |account| is failure, return (failure, true).
+            1. Set |accountState| to the result of running the [=compute the connection status=] algorithm
+                given |provider| and |account|.
+            1. If |accountState| is [=compute the connection status/disconnected=]:
+                1. Let |permission| be the result of running the [=request permission to sign-up=]
+                    algorithm with |account|, |config|, |provider|, and |globalObject|.
+                1. Set |disclosureTextShown| to true.
+            1. Otherwise, set |permission| to true.
+        </dl>
     1. Wait until the [=user agent=]'s dialogs requesting for user choice or permission to be
         closed, if any are created in the previous steps.
     1. Assert: |account| is not null.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -648,6 +648,8 @@ Given a |realm|, a {{DOMString}} |message|, and an {{IdentityCredentialErrorInit
     :   <b>{{IdentityCredentialError/error}}</b>
     ::  The {{IdentityCredentialError/error}}'s attribute getter returns the value it is set to.
         It represents the type of error which resulted in an {{IdentityCredential}} not being created.
+        An [=IDP=] MUST not expose sensitive user information in this field, since it is exposed to
+        the [=RP=].
     :   <b>{{IdentityCredentialError/url}}</b>
     ::  The {{IdentityCredentialError/url}}'s attribute getter returns the value it is set to.
         It represents a URL where the user can learn more information about the error.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1461,6 +1461,8 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
                     |errorUrl|.
             1. Set |credential| to the result of [=create an IdentityCredentialError=] with
                 |errorInit|, and |globalObject|.
+        1. Otherwise, if |response|'s [=response/status=] is an [=ok status=], set |credential| to
+            the result of [=create an IdentityCredentialError=] with {} and |globalObject|.
         1. Otherwise, if {{IdentityAssertionResponse/token}} was specified, let |tokenString|
             be |token|'s {{IdentityAssertionResponse/token}}.
         1. Otherwise, if {{IdentityAssertionResponse/continue_on}} was specified, run these steps

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -620,7 +620,7 @@ to use a federated account.
 
 <xmp class="idl">
 dictionary IdentityCredentialErrorInit {
-  DOMString code;
+  DOMString error;
   DOMString url;
 };
 </xmp>
@@ -629,7 +629,7 @@ dictionary IdentityCredentialErrorInit {
   [Exposed=Window, SecureContext]
   interface IdentityCredentialError : DOMException {
     constructor(optional DOMString message = "", optional IdentityCredentialErrorInit options = {});
-    readonly attribute DOMString code;
+    readonly attribute DOMString error;
     readonly attribute DOMString url;
   };
 </pre>
@@ -638,15 +638,15 @@ dictionary IdentityCredentialErrorInit {
 The {{IdentityCredentialError/constructor()}}, given a |realm|, a {{DOMString}} |message| and a
     {{IdentityCredentialErrorInit}} |options| must run the following steps:
     1. Invoke the {{DOMException}}'s {{DOMException/constructor()}}, passing |realm| and |message|.
-    1. Set <a>this</a>.{{IdentityCredentialError/code}} to |options|.{{IdentityCredentialError/code}}
+    1. Set <a>this</a>.{{IdentityCredentialError/error}} to |options|.{{IdentityCredentialError/error}}
         if it is present in |options|, or to "" otherwise.
     1. Set <a>this</a>.{{IdentityCredentialError/url}} to |options|.{{IdentityCredentialError/url}}
         if it is present in |options|, or to "" otherwise.
 </div>
 
 <dl>
-    :   <b>{{IdentityCredentialError/code}}</b>
-    ::  The {{IdentityCredentialError/code}}'s attribute getter returns the value it is set to.
+    :   <b>{{IdentityCredentialError/error}}</b>
+    ::  The {{IdentityCredentialError/error}}'s attribute getter returns the value it is set to.
         It represents the type of error which resulted in an {{IdentityCredential}} not being created.
     :   <b>{{IdentityCredentialError/url}}</b>
     ::  The {{IdentityCredentialError/url}}'s attribute getter returns the value it is set to.
@@ -1070,7 +1070,7 @@ throwing the exception.
     1. If |credential| is an {{IdentityCredentialError}}:
         1. The [=user agent=] MUST show UI to the user indicating that the identity assertion fetch
             has failed.
-        1. The [=user agent=] MAY use the {{IdentityCredentialError/code}} in its UI to provide a
+        1. The [=user agent=] MAY use the {{IdentityCredentialError/error}} in its UI to provide a
             more specific error message to the user. For instance, if the value is one of
             "invalid_request", "unauthorized_client", "access_denied", "server_error", and
             "temporarily_unavailable", the [=user agent=] may note the reason in a user-friendly

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1231,31 +1231,11 @@ or failure.
         1. [=converted to an IDL value|Convert=] |json| to an {{IdentityProviderAPIConfig}} stored
             in |config|.
         1. If one of the previous two steps threw an exception, set |config| to failure.
-        1. Set |login_url| to the result of [=computing the manifest URL=] with |provider|,
-            |config|.{{IdentityProviderAPIConfig/login_url}}, and |globalObject|.
-        1. Set |accounts_url| to the result of [=computing the manifest URL=] with |provider|,
-            |config|.{{IdentityProviderAPIConfig/accounts_endpoint}}, and |globalObject|.
-        1. If |login_url| or |accounts_url| is failure, set |config| to failure.
-    1. Wait for |config| to be set.
-    1. If |config| is failure, return failure.
-    1. If |skipWellKnown| is true, return |config|.
-    1. Wait for |wellKnown| to be set.
-    1. If |wellKnown| is failure, return failure.
-    1. If |wellKnown|.{{IdentityProviderWellKnown/accounts_endpoint}} and
-        |wellKnown|.{{IdentityProviderWellKnown/login_url}} are set:
-        1. Let |well_known_accounts_url| be the result of [=computing the manifest URL=] with
-            |provider|, |wellKnown|.{{IdentityProviderWellKnown/accounts_endpoint}},
-            and |globalObject|.
-        1. Let |well_known_login_url| be the result of [=computing the manifest URL=] with |provider|,
-            |wellKnown|.{{IdentityProviderWellKnown/login_url}}, and |globalObject|.
-        1. If |well_known_accounts_url| is not [=url/equal=] to |accounts_url|, return failure.
-        1. If |well_known_login_url| is not [=url/equal=] to |login_url|, return failure.
-    1. Otherwise:
-        1. Let |allowed_config_url| be the result of [=computing the manifest URL=] with |provider|,
-            |wellKnown|.{{IdentityProviderWellKnown/provider_urls}}[0], and |globalObject|.
-        1. If |allowed_config_url| is not [=url/equal=] to |configUrl|, return failure.
-    1. Return |config|.
-
+        1. Set |config|.{{IdentityProviderAPIConfig/login_url}} to the result of [=computing
+            the manifest URL=] with |provider|, |config|, true, and |globalObject|.
+        1. If |config|.{{IdentityProviderAPIConfig/login_url}} is null, return failure.
+    1. Wait for both |config| and |configInWellKnown| to be set.
+    1. If |configInWellKnown| is true, return |config|. Otherwise, return failure.
 </div>
 
 NOTE: a two-tier file system is used in order to prevent the [=IDP=] from easily determining the [=RP=]

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1461,8 +1461,8 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
                     |errorUrl|.
             1. Set |credential| to the result of [=create an IdentityCredentialError=] with
                 |errorInit|, and |globalObject|.
-        1. Otherwise, if |response|'s [=response/status=] is an [=ok status=], set |credential| to
-            the result of [=create an IdentityCredentialError=] with {} and |globalObject|.
+        1. Otherwise, if |response|'s [=response/status=] is not an [=ok status=], set |credential|
+            to the result of [=create an IdentityCredentialError=] with {} and |globalObject|.
         1. Otherwise, if {{IdentityAssertionResponse/token}} was specified, let |tokenString|
             be |token|'s {{IdentityAssertionResponse/token}}.
         1. Otherwise, if {{IdentityAssertionResponse/continue_on}} was specified, run these steps

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -989,84 +989,22 @@ throwing the exception.
 
             * If the [=show an IDP login dialog=] algorithm was triggered:
 
-                * If the user closes the dialog, return (failure, true).
-
-                * If the [=show an IDP login dialog=] algorithm was triggered:
-
-                    1. Let |result| be the result of that algorithm.
-                    1. If |result| is failure, return (failure, true). The user
-                        agent MAY show a dialog to the user before or after
-                        returning failure indicating this failure.
-                    1. Otherwise, go back to the [=fetch accounts step=].
-
-    1. Assert: |accountsList| is not failure and the size of |accountsList| is not 0.
-    1. [=Set the login status=] for the [=/origin=] of the
-        {{IdentityProviderConfig/configURL}} to [=logged-in=].
-    1. If |provider|'s {{IdentityProviderRequestOptions/loginHint}} is not empty:
-        1. For every |account| in |accountList|, remove |account| from |accountList| if |account|'s
-            {{IdentityProviderAccount/login_hints}} does not [=list/contain=] |provider|'s
-            {{IdentityProviderRequestOptions/loginHint}}.
-        1. If |accountList| is now empty, go to the [=mismatch dialog step=].
-    1. If |provider|'s {{IdentityProviderRequestOptions/domainHint}} is not empty:
-        1. For every |account| in |accountList|:
-            1. If {{IdentityProviderRequestOptions/domainHint}} is "any":
-                1. If |account|'s {{IdentityProviderAccount/domain_hints}} is empty, remove
-                    |account| from |accountList|.
-            1. Otherwise, remove |account| from |accountList| if |account|'s
-                {{IdentityProviderAccount/domain_hints}} does not [=list/contain=] |provider|'s
-                {{IdentityProviderRequestOptions/domainHint}}.
-        1. If |accountList| is now empty, go to the [=mismatch dialog step=].
-    1. For each |acc| in |accountsList|:
-        1. If |acc|["{{IdentityProviderAccount/picture}}"] is present, [=fetch the account picture=]
-            with |acc| and |globalObject|.
-
-        Note: The [=user agent=] may choose to show UI which does not initially require fetching the
-        account pictures. In these cases, the [=user agent=] may delay these fetches until they are
-        needed. Because errors from these fetches are ignored, they can happen in any order.
-    1. Let |registeredAccount|, |numRegisteredAccounts| be null and 0, respectively.
-    1. Let |account| be null.
-    1. For each |acc| in |accountsList|:
-        1. Let |accState| be the result of running the [=compute the connection status=] algorithm given
-            |provider| and |acc|.
-        1. If |accState| is [=compute the connection status/connected=], set |registeredAccount| to
-            |acc| and increase |numRegisteredAccounts| by 1.
-    1. Let |permission|, |disclosureTextShown|, and |isAutoSelected| be set to false.
-    1. Perform the set of instructions corresponding to the first matching statement:
-        <dl class=switch>
-        <dt>If |mediation| is not "{{CredentialMediationRequirement/required}}", |requiresUserMediation|
-        is false, and |numRegisteredAccounts| is equal to 1:</dt>
-            1. Set |account| to |registeredAccount|, |permission| to true, and |isAutoSelected| to true.
-                When doing this, the user agent MAY show some UI to the user indicating that they are being
-                <dfn>auto-reauthenticated</dfn>.
-        <dt>If |mediation| is "{{CredentialMediationRequirement/silent}}":</dt>
-            1. Return (failure, false).
-        <dt> If |accountsList|'s size is 1:</dt>
-            1. Set |account| to |accountsList|[0].
-            1. If [=compute the connection status=] of |account|, |provider| and |globalObject| returns
-                [=compute the connection status/connected=], show a dialog to request user permission to sign
-                in via |account|, and set the result in |permission|. The user agent MAY use |options|'s
-                {{IdentityCredentialRequestOptions/context}} to customize the dialog.
-            1. Otherwise, let |permission| be the result of running [=request permission to sign-up=]
-                algorithm with |account|, |config|, |provider|, and |globalObject|. Also set
-                |disclosureTextShown| to true.
-            1. Otherwise, show a dialog to request user permission to sign in via |account|, and set the
-                result in |permission|. The user agent MAY use |options|'s
-                {{IdentityCredentialRequestOptions/context}} to customize the dialog.
-        <dt>Otherwise:</dt>
-            1. Set |account| to the result of running the [=select an account=] from the
-                |accountsList|.
-            1. If |account| is failure, return (failure, true).
-            1. Set |accountState| to the result of running the [=compute the connection status=] algorithm
-                given |provider| and |account|.
-            1. If |accountState| is [=compute the connection status/disconnected=]:
-                1. Let |permission| be the result of running the [=request permission to sign-up=]
-                    algorithm with |account|, |config|, |provider|, and |globalObject|.
-                1. Set |disclosureTextShown| to true.
-            1. Otherwise, set |permission| to true.
-        </dl>
-    1. Wait until the [=user agent=]'s dialogs requesting for user choice or permission to be
-        closed, if any are created in the previous steps.
-    1. Assert: |account| is not null.
+                1. Let |result| be the result of that algorithm.
+                1. If |result| is failure, return (failure, true). The user
+                    agent MAY show a dialog to the user before or after
+                    returning failure indicating this failure.
+                1. Otherwise, go back to the [=fetch accounts step=] to get an updated
+                    value of |providerMap| for this [=IDP=].
+        1. Otherwise, |value| is a [=list=] of accounts. [=list/Extend=] |allAccounts| with |value|.
+    1. Also include a UI affordance to close the dialog. If the user closes this dialog, return (failure,
+        true).
+    1. <dfn for="create identity credential">Show accounts</dfn> step: if |allAccounts| is not
+        [=list/empty=], also add UI to present the account options to the user. If the user selects
+        an account, perform the following steps:
+            1. Set |selectedAccount| to the chosen {{IdentityProviderAccount}}.
+            1. Close the dialog.
+    1. If the [=user agent=] created any dialogs requesting user choice or permission in the previous
+        steps, wait until they are closed.
     1. If |permission| is false, then return (failure, true).
     1. Assert: |selectedAccount| is not null.
     1. Let |credential| be the result of running the [=fetch an identity assertion=] algorithm with

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1465,9 +1465,9 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
             1. Set |credential| to the result of [=create an IdentityCredentialError=] with {} and
                 |globalObject|.
             1. The user agent MAY set |credential|'s {{IdentityCredentialError/error}} based on
-                |response|'s [=response/status=]. For example, it could set it to "server_error" if
-                the [=response/status=] is 500 and it could set it to "temporarily_unavailable" if
-                the [=response/status=] is 503.
+                |response|'s [=response/status=]. For example, if the [=response/status=] is 500, it
+                could set it to "server_error", and if the [=response/status=] is 503, it could set
+                it to "temporarily_unavailable".
         1. Otherwise, if {{IdentityAssertionResponse/token}} was specified, let |tokenString|
             be |token|'s {{IdentityAssertionResponse/token}}.
         1. Otherwise, if {{IdentityAssertionResponse/continue_on}} was specified, run these steps
@@ -2344,9 +2344,9 @@ Every {{IdentityAssertionResponse}} is expected to have members with the followi
     ::  A dictionary containing the error that occurred when the ID assertion was fetched.
 </dl>
 
-Only one of `token`, `continue_on`, and `error` should be specified. When multiple are specified,
-the order of processing is [`error`, `token`, `continue_on`], so the first present will be used in
-the response.
+Only one of `token`, `continue_on`, or `error` should be specified. When multiple are specified,
+the order of processing is [`error`, `token`, `continue_on`], so the first encountered will be used
+in the response.
 
 The content of the {{IdentityAssertionResponse/token}} is opaque to the user agent and can contain
 anything that the [=IDP=] would like to pass to the

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1714,8 +1714,8 @@ following steps. This returns a <a spec=url for=/>URL</a> or failure.
     1. If |manifestUrl| is failure, return failure.
     1. If |requireSameOrigin| and |manifestUrl| is not [=same origin=] with |configUrl|, return
         failure.
-    1. If |requireSameOrigin| is false and |manifestUrl|'s <a spec=url>domain</a> is not equal to
-        |configUrl|'s, return failure.
+    1. If |requireSameOrigin| is false and |manifestUrl|'s [=url/host=]'s [=host/registrable domain=]
+        is not equal to |configUrl|'s, return failure.
     1. If |manifestUrl| is not a [=potentially trustworthy URL=], return failure.
     1. Return |manifestUrl|.
 </div>


### PR DESCRIPTION
Adds the capability for the FedCM API to show error dialogs in certain scenarios after the user has chosen to perform federated login with an account. For this purpose:

* An `IdentityCredentialError` is created, which may contain an `error` which is a string that contains the specific error, and the user agent may use to customize the UI). It may also contain `url`, in case the IDP wants to show a url where the user could get more information.
* Shows error UI when there are network errors or when the IDP returns that an error has occurred.

Fixes https://github.com/fedidcg/FedCM/issues/488


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/pull/498.html" title="Last updated on Jun 20, 2025, 6:09 PM UTC (5abb21d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/498/a17bc50...5abb21d.html" title="Last updated on Jun 20, 2025, 6:09 PM UTC (5abb21d)">Diff</a>