### PR TITLE
Mention SameSite cookies in accounts fetch

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -330,10 +330,10 @@ const credential = await navigator.credentials.get({
 ```
 </div>
 
-For fetches that are sent with cookies, unpartitioned
+When fetches are sent with cookies, unpartitioned
 [SameSite](https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-the-samesite-attribute-2)=None
 cookies are included. It doesn't introduce security issues on the API even when third-party cookies are otherwise
-disabled because the [=RP=] cannot inspect the results from the fetches on its own (e.g. the browser mediates what
+disabled because the [=RP=] cannot inspect the results from the fetches on its own (i.e., the browser mediates what
 the [=RP=] can receive).
 
 <!-- ============================================================ -->

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -330,13 +330,11 @@ const credential = await navigator.credentials.get({
 ```
 </div>
 
-For fetches that are sent with cookies, unpartitioned cookies are included,
-as if the resource was loaded as a same-origin request, e.g.
-regardless of the
-[SameSite](https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-the-samesite-attribute-2)
-value (which is used when a resource loaded as a third-party, not first-party). This makes it easy
-for an [=IDP=] to adopt the FedCM API. It doesn't introduce security issues on the API because the
-[=RP=] cannot inspect the results from the fetches in any way.
+For fetches that are sent with cookies, unpartitioned
+[SameSite](https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-the-samesite-attribute-2)=None
+cookies are included. This makes it easy for an [=IDP=] to adopt the FedCM API. It doesn't introduce
+security issues on the API because the [=RP=] cannot inspect the results from the fetches on its
+own (e.g. the browser mediates what the [=RP=] can receive).
 
 <!-- ============================================================ -->
 ## The connected accounts set ## {#browser-connected-accounts-set}
@@ -1111,7 +1109,7 @@ returns an {{IdentityProviderAccountList}}.
         with [=request/mode=] set to "user-agent-no-cors". See the relevant
         [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
 
-        Note: This fetch should only send Same-Site None cookies. Specifying this will require cookie layering.
+        Note: This fetch should only send Same-Site=None cookies. Specifying this will require cookie layering.
 
     1. Let |accountsList| be null.
     1. [=Fetch request=] with |request| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1111,6 +1111,8 @@ returns an {{IdentityProviderAccountList}}.
         with [=request/mode=] set to "user-agent-no-cors". See the relevant
         [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
 
+        Note: This fetch should only send Same-Site None cookies. Specifying this will require cookie layering.
+
     1. Let |accountsList| be null.
     1. [=Fetch request=] with |request| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
         set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -332,9 +332,9 @@ const credential = await navigator.credentials.get({
 
 For fetches that are sent with cookies, unpartitioned
 [SameSite](https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-the-samesite-attribute-2)=None
-cookies are included. This makes it easy for an [=IDP=] to adopt the FedCM API. It doesn't introduce
-security issues on the API because the [=RP=] cannot inspect the results from the fetches on its
-own (e.g. the browser mediates what the [=RP=] can receive).
+cookies are included. It doesn't introduce security issues on the API even when third-party cookies are otherwise
+disabled because the [=RP=] cannot inspect the results from the fetches on its own (e.g. the browser mediates what
+the [=RP=] can receive).
 
 <!-- ============================================================ -->
 ## The connected accounts set ## {#browser-connected-accounts-set}
@@ -1109,7 +1109,8 @@ returns an {{IdentityProviderAccountList}}.
         with [=request/mode=] set to "user-agent-no-cors". See the relevant
         [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
 
-        Note: This fetch should only send Same-Site=None cookies. Specifying this will require cookie layering.
+        Note: This fetch should only send Same-Site=None cookies. Specifying this will require
+        [cookie layering](https://github.com/httpwg/http-extensions/issues/2084).
 
     1. Let |accountsList| be null.
     1. [=Fetch request=] with |request| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>


### PR DESCRIPTION
This PR adds a mention to which cookies ought to be sent in the accounts fetch. Once cookie layering work is done, we can remove this note and properly specify it.

Relevant issue: https://github.com/fedidcg/FedCM/issues/609


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/pull/550.html" title="Last updated on Sep 23, 2024, 10:21 PM UTC (662dc2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/550/721c213...662dc2e.html" title="Last updated on Sep 23, 2024, 10:21 PM UTC (662dc2e)">Diff</a>