### PR TITLE
Fix the link to the Web Platform Tests

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -21,7 +21,7 @@ Text Macro: IDP Identity Provider
 
 Abstract: A Web Platform API that allows users to login to websites with their federated accounts in a privacy preserving manner.
 
-Test Suite: https://github.com/web-platform-tests/wpt/blob/master/credential-management/
+Test Suite: https://github.com/web-platform-tests/wpt/tree/master/fedcm
 </pre>
 
 <pre class=anchors>


### PR DESCRIPTION
We recently moved our tests to a different directories. This CL updates the references.