### PR TITLE
[link-validator] Missing file context-api.md

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2412,10 +2412,6 @@ The [=remote end steps=] are:
     </table>
 </figure>
 
-Note: This command lets automation verify that the
-    [context api](https://github.com/fedidcg/FedCM/blob/main/proposals/context-api.md)
-    was applied properly
-
 The [=remote end steps=] are:
 
 1. If no FedCM dialog is currently open, return a [=error|WebDriver error=] with

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2412,6 +2412,10 @@ The [=remote end steps=] are:
     </table>
 </figure>
 
+ Note: This command lets automation verify that the
+  [context api](#dom-identitycredentialrequestoptions-context)
+     was applied properly
+
 The [=remote end steps=] are:
 
 1. If no FedCM dialog is currently open, return a [=error|WebDriver error=] with

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2412,7 +2412,7 @@ The [=remote end steps=] are:
     </table>
 </figure>
 
- Note: This command lets automation verify that the
+Note: This command lets automation verify that the
   [context api](#dom-identitycredentialrequestoptions-context)
      was applied properly
 


### PR DESCRIPTION
Hello,

There is a note with a broken reference link.

`Note: This command lets automation verify that the
   [context api](https://github.com/fedidcg/FedCM/blob/main/proposals/context-api.md)
    was applied properly`

I searched inside the repo and could not find it.

I am proposing to remove it, if it not exist anymore. Otherwise feel free to modify the PR.

Thanks,

Simone

P.S. This should be the last check for publication in `/TR`