### PR TITLE
Use the Editor's Draft boilerplate on fedid-wg.github.io/FedCM

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2,7 +2,7 @@
 Title: Federated Credential Management API
 Shortname: fedcm
 Level: 1
-Status: w3c/FPWD
+Status: w3c/ED
 Group: fedid
 TR: http://www.w3.org/TR/fedcm/
 ED: https://w3c-fedid.github.io/FedCM/


### PR DESCRIPTION
This changes the boilerplate to the Editor's Draft (ED) auto-published on https://fedid-wg.github.io/FedCM/.

as per the group decision here: https://github.com/w3c-fedid/meetings/blob/main/2024/2024-07-30-notes.md