### PR TITLE
Disambiguate [=remote end steps=]

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -62,6 +62,7 @@ spec:html; type:dfn; for:environment settings object; text:global object
 spec:html; type:dfn; for:html-origin-def; text:origin
 spec:webidl; type:dfn; text:resolve
 spec:webdriver2; type:dfn; text:error
+spec:webdriver2; type:dfn; text:remote end steps
 spec:fetch; type:dfn; for:/; text:response
 </pre>
 


### PR DESCRIPTION
This fixes this bikeshed warning:
```
LINE ~2116: Multiple possible 'remote end steps' dfn refs.
Arbitrarily chose https://patcg-individual-drafts.github.io/private-aggregation-api/#remote-end-steps
To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
spec:private-aggregation-api; type:dfn; text:remote end steps
spec:webdriver2; type:dfn; text:remote end steps
[=remote end steps=]
```

Apparently the private aggregation API recently added a
definition for `remote end steps`.