### PR TITLE
Download profile pictures before filtering accounts

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -854,7 +854,7 @@ the exception thrown.
 
         Note: We require downloading the pictures here before we potentially filter the account
             list so that the identity provider cannot determine the provided hints based
-            on which fetches occured.
+            on which fetches occurred.
     1. If |provider|'s {{IdentityProviderRequestOptions/loginHint}} is not empty:
         1. For every |account| in |accountList|, remove |account| from |accountList| if |account|'s
             {{IdentityProviderAccount/login_hints}} does not [=list/contain=] |provider|'s

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -853,8 +853,8 @@ the exception thrown.
             the picture.
 
         Note: We require downloading the pictures here before we potentially filter the account
-            list so that the identity provider cannot determine the provided hints based
-            on which fetches occurred.
+            list so that the identity provider cannot determine what hints were provided
+            based on which fetches occurred.
     1. If |provider|'s {{IdentityProviderRequestOptions/loginHint}} is not empty:
         1. For every |account| in |accountList|, remove |account| from |accountList| if |account|'s
             {{IdentityProviderAccount/login_hints}} does not [=list/contain=] |provider|'s

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -846,6 +846,15 @@ the exception thrown.
     1. Assert: |accountsList| is not failure and the size of |accountsList| is not 0.
     1. [=Set the login status=] for the [=/origin=] of the
         {{IdentityProviderConfig/configURL}} to [=logged-in=].
+    1. For each |acc| in |accountsList|:
+        1. If |acc|["{{IdentityProviderAccount/picture}}"] is present, [=fetch the account picture=]
+            with |acc| and |globalObject|. If the [=user agent=] displays this picture to
+            the user at any point, it MUST reuse the result of this fetch instead of redownloading
+            the picture.
+
+        Note: We require downloading the pictures here before we potentially filter the account
+            list so that the identity provider cannot determine the provided hints based
+            on which fetches occured.
     1. If |provider|'s {{IdentityProviderRequestOptions/loginHint}} is not empty:
         1. For every |account| in |accountList|, remove |account| from |accountList| if |account|'s
             {{IdentityProviderAccount/login_hints}} does not [=list/contain=] |provider|'s
@@ -860,13 +869,6 @@ the exception thrown.
                 {{IdentityProviderAccount/domain_hints}} does not [=list/contain=] |provider|'s
                 {{IdentityProviderRequestOptions/domainHint}}.
         1. If |accountList| is now empty, go to the [=mismatch dialog step=].
-    1. For each |acc| in |accountsList|:
-        1. If |acc|["{{IdentityProviderAccount/picture}}"] is present, [=fetch the account picture=]
-            with |acc| and |globalObject|.
-
-        Note: The [=user agent=] may choose to show UI which does not initially require fetching the
-        account pictures. In these cases, the [=user agent=] may delay these fetches until they are
-        needed. Because errors from these fetches are ignored, they can happen in any order.
     1. Let |registeredAccount|, |numRegisteredAccounts| be null and 0, respectively.
     1. Let |account| be null.
     1. For each |acc| in |accountsList|:


### PR DESCRIPTION
For privacy reasons, all pictures should be downloaded before filtering the list according to provided login or domain hints.

Fixed: #672


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cbiesinger/WebID/pull/670.html" title="Last updated on Oct 30, 2024, 7:25 PM UTC (5a62392)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/670/026dbaa...cbiesinger:5a62392.html" title="Last updated on Oct 30, 2024, 7:25 PM UTC (5a62392)">Diff</a>