### PR TITLE
Replace link to Explainer with Developer Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the repository for the W3C's FedID CG Federated Credentials Management API.
 
-Explainer: [explainer.md](explainer.md)
+Developer documentation: [Federated Credential Management (FedCM) API]([explainer.md](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API))
 
 Work-in-progress specification: <https://w3c-fedid.github.io/FedCM/>
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ as they were the primitives provided by the web.
 
 The [documentation](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API)
 and [spec](https://w3c-fedid.github.io/FedCM) provide a potential API and the
-rational behind how that API was designed.
+rationale behind that API's design.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the repository for the W3C's FedID CG Federated Credentials Management API.
 
-Developer documentation: [Federated Credential Management (FedCM) API]([explainer.md](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API))
+Developer documentation: [Federated Credential Management (FedCM) API](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API)
 
 Work-in-progress specification: <https://w3c-fedid.github.io/FedCM/>
 
@@ -21,8 +21,9 @@ the removal of third-party cookies on federated login. Historically this has
 relied on third-party cookies or navigational redirects in order to function
 as they were the primitives provided by the web.
 
-The [explainer](explainer.md) and [spec](https://w3c-fedid.github.io/FedCM)
-provide a potential API and the rational behind how that API was designed.
+The [documentation](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API)
+and [spec](https://w3c-fedid.github.io/FedCM) provide a potential API and the
+rational behind how that API was designed.
 
 ## Contributing
 


### PR DESCRIPTION
The explainer has been deleted per https://github.com/w3c-fedid/FedCM/issues/622.
The link to it in the README.md is being replaced here with the MDN documentation