### PR TITLE
Allow user agent to wait or reject the request before any fetch

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -731,11 +731,6 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
 
 
         Issue: Support choosing accounts from multiple [=IDP=]s, as described [here](https://github.com/fedidcg/FedCM/issues/319).
-    1. The user agent can decide when to continue with the next steps.
-
-        Note: For example, user agents may show an identity provider selector before making
-            network requests, or provide a button in the URL bar and wait for user input
-            before continuing.
     1. Let |provider| be |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"][0].
     1. Let |credential| be the result of running [=create an IdentityCredential=] with |provider|,
         |options|, and |globalObject|.
@@ -775,6 +770,15 @@ To <dfn>create an IdentityCredential</dfn> given an {{IdentityProviderRequestOpt
 or a pair (failure, bool), where the bool indicates whether to skip delaying
 the exception thrown.
     1. Assert: These steps are running [=in parallel=].
+    1. The user agent MAY wait an arbitrary amount of time before continuing with the
+        next steps. The user agent MAY also return (failure, false) at this point or
+        after some arbitrary wait.
+
+        Note: For example, the user agent could show an identity provider selector and
+            only proceed once the user confirms their desire to use an identity provider.
+            Or the user agent could provide a button in the URL bar and wait for user
+            input before continuing. Or the user agent could use previous user behavior
+            to determine not to show any UI to the user and silently reject the request.
     1. Let |loginStatus| be the result of [=get the login status=] with
         the [=/origin=] of |provider|'s {{IdentityProviderConfig/configURL}}.
     1. If |loginStatus| is [=unknown=], a user agent MAY set it to [=logged-out=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -774,13 +774,15 @@ the exception thrown.
         next steps. The user agent MAY also return (failure, false) at this point or
         after some arbitrary wait.
 
-        Note: For example, the user agent could:
+        <div class="note">
+        NOTE: For example, the user agent could:
             * Show an identity provider selector and only proceed once
                   the user confirms their desire to use an identity provider.
             * Provide a button in the URL bar and wait for user input
                   before continuing. 
             * Use previous user behavior to determine not to show any
                   UI to the user and silently reject the request.
+        </div>
     1. Let |loginStatus| be the result of [=get the login status=] with
         the [=/origin=] of |provider|'s {{IdentityProviderConfig/configURL}}.
     1. If |loginStatus| is [=unknown=], a user agent MAY set it to [=logged-out=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -804,6 +804,8 @@ the exception thrown.
     1. Let |config| be the result of running [=fetch the config file=] with
         |provider| and |globalObject|.
     1. If |config| is failure, return (failure, false).
+    1. The user agent MAY show a dialog to request the user to confirm that they would like to use FedCM
+    with the IDP. If the user rejects this dialog, return (failure, false).
     1. <dfn>Fetch accounts step</dfn>: Let |accountsList| be the result of
         [=fetch the accounts=] with |config|, |provider|, and |globalObject|.
     1. If |accountsList| is failure, or the size of |accountsList| is 0:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -774,11 +774,13 @@ the exception thrown.
         next steps. The user agent MAY also return (failure, false) at this point or
         after some arbitrary wait.
 
-        Note: For example, the user agent could show an identity provider selector and
-            only proceed once the user confirms their desire to use an identity provider.
-            Or the user agent could provide a button in the URL bar and wait for user
-            input before continuing. Or the user agent could use previous user behavior
-            to determine not to show any UI to the user and silently reject the request.
+        Note: For example, the user agent could —
+        * show an identity provider selector and only proceed once
+          the user confirms their desire to use an identity provider.
+        * provide a button in the URL bar and wait for user input
+          before continuing. 
+        * use previous user behavior to determine not to show any
+          UI to the user and silently reject the request.
     1. Let |loginStatus| be the result of [=get the login status=] with
         the [=/origin=] of |provider|'s {{IdentityProviderConfig/configURL}}.
     1. If |loginStatus| is [=unknown=], a user agent MAY set it to [=logged-out=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -775,7 +775,7 @@ the exception thrown.
         after some arbitrary wait.
 
         <div class="note">
-        NOTE: For example, the user agent could:
+        NOTE: For example, the user agent could do any of the following:
             * Show an identity provider selector and only proceed once
                   the user confirms their desire to use an identity provider.
             * Provide a button in the URL bar and wait for user input

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -774,13 +774,13 @@ the exception thrown.
         next steps. The user agent MAY also return (failure, false) at this point or
         after some arbitrary wait.
 
-        Note: For example, the user agent could —
-        * show an identity provider selector and only proceed once
-          the user confirms their desire to use an identity provider.
-        * provide a button in the URL bar and wait for user input
-          before continuing. 
-        * use previous user behavior to determine not to show any
-          UI to the user and silently reject the request.
+        Note: For example, the user agent could:
+            * Show an identity provider selector and only proceed once
+                  the user confirms their desire to use an identity provider.
+            * Provide a button in the URL bar and wait for user input
+                  before continuing. 
+            * Use previous user behavior to determine not to show any
+                  UI to the user and silently reject the request.
     1. Let |loginStatus| be the result of [=get the login status=] with
         the [=/origin=] of |provider|'s {{IdentityProviderConfig/configURL}}.
     1. If |loginStatus| is [=unknown=], a user agent MAY set it to [=logged-out=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -808,8 +808,6 @@ the exception thrown.
     1. Let |config| be the result of running [=fetch the config file=] with
         |provider| and |globalObject|.
     1. If |config| is failure, return (failure, false).
-    1. The user agent MAY show a dialog to request the user to confirm that they would like to use FedCM
-        with the IDP. If the user rejects this dialog, return (failure, false).
     1. <dfn>Fetch accounts step</dfn>: Let |accountsList| be the result of
         [=fetch the accounts=] with |config|, |provider|, and |globalObject|.
     1. If |accountsList| is failure, or the size of |accountsList| is 0:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -805,7 +805,7 @@ the exception thrown.
         |provider| and |globalObject|.
     1. If |config| is failure, return (failure, false).
     1. The user agent MAY show a dialog to request the user to confirm that they would like to use FedCM
-    with the IDP. If the user rejects this dialog, return (failure, false).
+        with the IDP. If the user rejects this dialog, return (failure, false).
     1. <dfn>Fetch accounts step</dfn>: Let |accountsList| be the result of
         [=fetch the accounts=] with |config|, |provider|, and |globalObject|.
     1. If |accountsList| is failure, or the size of |accountsList| is 0:


### PR DESCRIPTION
See https://github.com/w3c-fedid/FedCM/issues/675


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/pull/676.html" title="Last updated on Feb 12, 2025, 9:49 PM UTC (91d9550)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/676/74852ac...91d9550.html" title="Last updated on Feb 12, 2025, 9:49 PM UTC (91d9550)">Diff</a>