### PR TITLE
Remove 'signed assertions about the user'

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1999,7 +1999,7 @@ For example:
 ## Identity assertion endpoint ## {#idp-api-id-assertion-endpoint}
 <!-- ============================================================ -->
 
-The <dfn>identity assertion endpoint</dfn> is responsible for minting a new token that contains signed assertions about the user.
+The <dfn>identity assertion endpoint</dfn> is responsible for minting a new token.
 
 The [=identity assertion endpoint=] is fetched in the [=fetch an identity assertion=] algorithm:
 


### PR DESCRIPTION
Given FedCM is unopinionated about what information a token carries, 'The content of the token ... can contain anything that the IDP would like to pass to the RP to facilitate the login'. Maybe this description should not say it will contain signed user assertions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/philsmart/FedCM/pull/684.html" title="Last updated on Nov 27, 2024, 4:29 PM UTC (5cdc63a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/684/8201e01...philsmart:5cdc63a.html" title="Last updated on Nov 27, 2024, 4:29 PM UTC (5cdc63a)">Diff</a>