### PR TITLE
Remove 'authenticate .... tokens'

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -134,8 +134,7 @@ permission before allowing the [=RPs=] and [=IDPs=] to know about their
 connection to the user.
 
 The specification leans heavily on changes in the [=user agent=] and [=IDP=]
-and minimally on the [=RP=]. The FedCM API provides a way to authenticate and
-fetch tokens.
+and minimally on the [=RP=]. The FedCM API provides a way to fetch tokens.
 
 <div class=example>
 Example showing how a website allowing for a single logged in account


### PR DESCRIPTION
I am not sure FedCM provides a way to authenticate tokens, just fetch them. Maybe 'authenticate' should be removed. Unless it is referring to some other kind of authentication, however.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/philsmart/FedCM/pull/693.html" title="Last updated on Jan 16, 2025, 5:28 PM UTC (a744322)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/693/fdb085e...philsmart:a744322.html" title="Last updated on Jan 16, 2025, 5:28 PM UTC (a744322)">Diff</a>