### PR TITLE
Fix bikeshed syntax error

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1574,8 +1574,8 @@ success or failure.
                 with the [=/origin=] of the {{IdentityProviderAPIConfig/login_url}}.
 
                 Note: The IDP login flow may set this value to logged-in using
-                    either the [login-status.html#login-status-javascript](JavaScript) or
-                    [login-status.html#login-status-http](HTTP header) API during the login
+                    either the [JavaScript](login-status.html#login-status-javascript) or
+                    [HTTP header](login-status.html#login-status-http) API during the login
                     flow. It is also possible that this change happened in
                     a different browsing context.
             1. If |loginStatus| is [=logged-in=], return success.


### PR DESCRIPTION
The link destination goes after the link text.

This was introduced in #642, but apparently bikeshed has gotten more strict since then and now produces an error for this line.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cbiesinger/WebID/pull/706.html" title="Last updated on Mar 12, 2025, 9:15 PM UTC (e0ae476)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/706/c8d6430...cbiesinger:e0ae476.html" title="Last updated on Mar 12, 2025, 9:15 PM UTC (e0ae476)">Diff</a>