### PR TITLE
Disambiguate "allowed to use"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -65,6 +65,7 @@ spec:webdriver2; type:dfn; text:error
 spec:webdriver2; type:dfn; text:remote end steps
 spec:fetch; type:dfn; for:/; text:response
 spec:css-color-5; type:type; text:<color>
+spec:html; type:dfn; text:allowed to use
 </pre>
 
 <style>


### PR DESCRIPTION
There is now another definition in the private aggregation API, so disambiguate it to the HTML spec.

Fixes a bikeshed warning.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cbiesinger/WebID/pull/707.html" title="Last updated on Mar 12, 2025, 9:29 PM UTC (f2687b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/707/afdb42b...cbiesinger:f2687b7.html" title="Last updated on Mar 12, 2025, 9:29 PM UTC (f2687b7)">Diff</a>