### PR TITLE
Make client metadata optional

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1170,7 +1170,7 @@ dictionary IdentityProviderBranding {
 
 dictionary IdentityProviderAPIConfig {
   required USVString accounts_endpoint;
-  required USVString client_metadata_endpoint;
+  USVString client_metadata_endpoint;
   required USVString id_assertion_endpoint;
   required USVString login_url;
   USVString disconnect_endpoint;
@@ -1496,6 +1496,8 @@ an {{IdentityProviderAPIConfig}} |config|, an {{IdentityProviderRequestOptions}}
 To <dfn noexport>fetch the client metadata</dfn> given an {{IdentityProviderAPIConfig}} |config| and
 an {{IdentityProviderRequestOptions}} |provider|, run the following steps. This returns an
 {{IdentityProviderClientMetadata}} or failure.
+    1. If |config|["{{IdentityProviderAPIConfig/client_metadata_endpoint}}"] is not present, return
+        failure.
     1. Let |clientMetadataUrl| be the result of [=computing the manifest URL=] given |provider|,
         |config|["{{IdentityProviderAPIConfig/client_metadata_endpoint}}"], and |globalObject|.
     1. If |clientMetadataUrl| is failure, return failure.


### PR DESCRIPTION
Fixes https://github.com/w3c-fedid/FedCM/issues/701


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/pull/716.html" title="Last updated on Apr 15, 2025, 7:34 PM UTC (a01c39b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/716/a5cd6fe...a01c39b.html" title="Last updated on Apr 15, 2025, 7:34 PM UTC (a01c39b)">Diff</a>