### PR TITLE
Add `tel` and `username` attributes

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1238,7 +1238,14 @@ returns an {{IdentityProviderAccountList}}.
             |responseBody|.
         1. [=converted to an IDL value|Convert=] |json| to an {{IdentityProviderAccountList}}, and
             store the result in |accountsList|.
-        1. If one of the previous two steps threw an exception, set |accountsList| to failure.
+        1. If one of the previous two steps threw an exception, or if there is an account in
+            |accountsList| that has none of {{IdentityProviderAccount/email}}, {{IdentityProviderAccount/name}},
+            {{IdentityProviderAccount/phone}} and {{IdentityProviderAccount/username}} set, set |accountsList|
+            to failure.
+
+        Note: If the user agent only has space to display two attributes in its account choosers,
+            it SHOULD display the first two that are provided in the order `name`, `username`,
+            `email` and `phone`.
 
         Issue: the accounts list returned here should be validated for repeated ids, as described
         [here](https://github.com/fedidcg/FedCM/issues/336).
@@ -1250,8 +1257,10 @@ returns an {{IdentityProviderAccountList}}.
 <xmp class="idl">
 dictionary IdentityProviderAccount {
   required USVString id;
-  required USVString name;
-  required USVString email;
+  USVString name;
+  USVString email;
+  USVString phone;
+  USVString username;
   USVString given_name;
   USVString picture;
   sequence<USVString> approved_clients;
@@ -1481,6 +1490,10 @@ an {{IdentityProviderAPIConfig}} |config|, an {{IdentityProviderRequestOptions}}
                 :: The user's name as given in {{IdentityProviderAccount}}.{{IdentityProviderAccount/name}}.
                 : `"email"`
                 :: The user's email address as given in {{IdentityProviderAccount}}.{{IdentityProviderAccount/email}}.
+                : `"phone"`
+                :: The user's phone number as given in {{IdentityProviderAccount}}.{{IdentityProviderAccount/phone}}.
+                : `"username"`
+                :: The user's username as given in {{IdentityProviderAccount}}.{{IdentityProviderAccount/username}}.
                 : `"picture"`
                 :: The user's profile picture as given in {{IdentityProviderAccount}}.{{IdentityProviderAccount/picture}}.
 
@@ -2029,7 +2042,8 @@ Sec-Fetch-Dest: webidentity
 
 The response body must be a JSON object that can be [=converted to an IDL value|converted=] to an {{IdentityProviderAccountList}} without an exception.
 
-Every {{IdentityProviderAccount}} is expected to have members with the following semantics:
+Every {{IdentityProviderAccount}} is expected to have members with the following semantics. `name`,
+`email`, `username` and `phone` are optional but at least one of them must be present and nonempty.
 
 <dl dfn-type="dict-member" dfn-for="IdentityProviderAccount">
     :   <dfn>id</dfn>
@@ -2038,6 +2052,10 @@ Every {{IdentityProviderAccount}} is expected to have members with the following
     ::  The user's full name.
     :   <dfn>email</dfn>
     ::  The user's email address.
+    :   <dfn>phone</dfn>
+    ::  The user's phone number.
+    :   <dfn>username</dfn>
+    ::  The user's username.
     :   <dfn>given_name</dfn>
     ::  The user's given name.
     :   <dfn>picture</dfn>
@@ -2078,7 +2096,6 @@ For example:
   }, {
    "id": "5678",
    "given_name": "Johnny",
-   "name": "Johnny",
    "email": "johnny@idp.example",
    "picture": "https://idp.example/profile/456",
    "approved_clients": ["abc", "def", "ghi"],

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1240,12 +1240,12 @@ returns an {{IdentityProviderAccountList}}.
             store the result in |accountsList|.
         1. If one of the previous two steps threw an exception, or if there is an account in
             |accountsList| that has neither {{IdentityProviderAccount/email}}, {{IdentityProviderAccount/name}},
-            {{IdentityProviderAccount/phone}}, nor {{IdentityProviderAccount/username}} set, set |accountsList|
+            {{IdentityProviderAccount/tel}}, nor {{IdentityProviderAccount/username}} set, set |accountsList|
             to failure.
 
         Note: If the user agent only has space to display two attributes in its account choosers,
             it SHOULD display the first two that are set, in the order `name`, `username`,
-            `email`, and `phone`.
+            `email`, and `tel`.
 
         Issue: the accounts list returned here should be validated for repeated ids, as described
         [here](https://github.com/fedidcg/FedCM/issues/336).
@@ -1259,7 +1259,7 @@ dictionary IdentityProviderAccount {
   required USVString id;
   USVString name;
   USVString email;
-  USVString phone;
+  USVString tel;
   USVString username;
   USVString given_name;
   USVString picture;
@@ -1490,8 +1490,8 @@ an {{IdentityProviderAPIConfig}} |config|, an {{IdentityProviderRequestOptions}}
                 :: The user's name as given in {{IdentityProviderAccount}}.{{IdentityProviderAccount/name}}.
                 : `"email"`
                 :: The user's email address as given in {{IdentityProviderAccount}}.{{IdentityProviderAccount/email}}.
-                : `"phone"`
-                :: The user's phone number as given in {{IdentityProviderAccount}}.{{IdentityProviderAccount/phone}}.
+                : `"tel"`
+                :: The user's phone number as given in {{IdentityProviderAccount}}.{{IdentityProviderAccount/tel}}.
                 : `"username"`
                 :: The user's username as given in {{IdentityProviderAccount}}.{{IdentityProviderAccount/username}}.
                 : `"picture"`
@@ -2043,7 +2043,7 @@ Sec-Fetch-Dest: webidentity
 The response body must be a JSON object that can be [=converted to an IDL value|converted=] to an {{IdentityProviderAccountList}} without an exception.
 
 Every {{IdentityProviderAccount}} is expected to have members with the following semantics. `name`,
-`email`, `username`, and `phone` are optional but at least one of them must be present and nonempty.
+`email`, `username`, and `tel` are optional but at least one of them must be present and nonempty.
 
 <dl dfn-type="dict-member" dfn-for="IdentityProviderAccount">
     :   <dfn>id</dfn>
@@ -2052,8 +2052,11 @@ Every {{IdentityProviderAccount}} is expected to have members with the following
     ::  The user's full name.
     :   <dfn>email</dfn>
     ::  The user's email address.
-    :   <dfn>phone</dfn>
+    :   <dfn>tel</dfn>
     ::  The user's phone number.
+
+        Note: As this is only meant to be shown to the user, we are not requirings
+            the phone number to be in any particular format.
     :   <dfn>username</dfn>
     ::  The user's username.
     :   <dfn>given_name</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2055,8 +2055,8 @@ Every {{IdentityProviderAccount}} is expected to have members with the following
     :   <dfn>tel</dfn>
     ::  The user's phone number.
 
-        Note: As this is only meant to be shown to the user, we are not requirings
-            the phone number to be in any particular format.
+        Note: As this is only meant to be shown to the user, the phone number
+              can be in any format.
     :   <dfn>username</dfn>
     ::  The user's username.
     :   <dfn>given_name</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1239,13 +1239,13 @@ returns an {{IdentityProviderAccountList}}.
         1. [=converted to an IDL value|Convert=] |json| to an {{IdentityProviderAccountList}}, and
             store the result in |accountsList|.
         1. If one of the previous two steps threw an exception, or if there is an account in
-            |accountsList| that has none of {{IdentityProviderAccount/email}}, {{IdentityProviderAccount/name}},
-            {{IdentityProviderAccount/phone}} and {{IdentityProviderAccount/username}} set, set |accountsList|
+            |accountsList| that has neither {{IdentityProviderAccount/email}}, {{IdentityProviderAccount/name}},
+            {{IdentityProviderAccount/phone}}, nor {{IdentityProviderAccount/username}} set, set |accountsList|
             to failure.
 
         Note: If the user agent only has space to display two attributes in its account choosers,
-            it SHOULD display the first two that are provided in the order `name`, `username`,
-            `email` and `phone`.
+            it SHOULD display the first two that are set, in the order `name`, `username`,
+            `email`, and `phone`.
 
         Issue: the accounts list returned here should be validated for repeated ids, as described
         [here](https://github.com/fedidcg/FedCM/issues/336).
@@ -2043,7 +2043,7 @@ Sec-Fetch-Dest: webidentity
 The response body must be a JSON object that can be [=converted to an IDL value|converted=] to an {{IdentityProviderAccountList}} without an exception.
 
 Every {{IdentityProviderAccount}} is expected to have members with the following semantics. `name`,
-`email`, `username` and `phone` are optional but at least one of them must be present and nonempty.
+`email`, `username`, and `phone` are optional but at least one of them must be present and nonempty.
 
 <dl dfn-type="dict-member" dfn-for="IdentityProviderAccount">
     :   <dfn>id</dfn>


### PR DESCRIPTION
Also makes `name` and `email` optional but requires that one of these four is provided.

Bug: #435


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cbiesinger/WebID/pull/718.html" title="Last updated on Apr 22, 2025, 7:15 PM UTC (06d95c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/718/c85489a...cbiesinger:06d95c0.html" title="Last updated on Apr 22, 2025, 7:15 PM UTC (06d95c0)">Diff</a>