### PR TITLE
Do not set request's window

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -576,8 +576,6 @@ perform the following steps. This returns an {{USVString}} or failure.
         :: "error"
         :  [=request/client=]
         :: null
-        :  [=request/window=]
-        :: "no-window"
         :  [=request/service-workers mode=]
         :: "none"
         :  [=request/destination=]
@@ -1042,8 +1040,6 @@ or failure.
             :: |rootUrl|
             :  [=request/client=]
             :: null
-            :  [=request/window=]
-            :: "no-window"
             :  [=request/service-workers mode=]
             :: "none"
             :  [=request/destination=]
@@ -1085,8 +1081,6 @@ or failure.
         :: "error"
         :  [=request/client=]
         :: null
-        :  [=request/window=]
-        :: "no-window"
         :  [=request/service-workers mode=]
         :: "none"
         :  [=request/destination=]
@@ -1202,8 +1196,6 @@ returns an {{IdentityProviderAccountList}}.
         :: "error"
         :  [=request/client=]
         :: null
-        :  [=request/window=]
-        :: "no-window"
         :  [=request/service-workers mode=]
         :: "none"
         :  [=request/destination=]
@@ -1285,8 +1277,6 @@ To <dfn>fetch the account picture</dfn> given an {{IdentityProviderAccount}} |ac
         :: |pictureUrl|
         :  [=request/client=]
         :: null
-        :  [=request/window=]
-        :: "no-window"
         :  [=request/service-workers mode=]
         :: "none"
         :  [=request/destination=]
@@ -1351,8 +1341,6 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
         :: "error"
         :  [=request/client=]
         :: null
-        :  [=request/window=]
-        :: "no-window"
         :  [=request/service-workers mode=]
         :: "none"
         :  [=request/destination=]
@@ -1522,8 +1510,6 @@ an {{IdentityProviderRequestOptions}} |provider|, run the following steps. This 
         :: "error"
         :  [=request/client=]
         :: null
-        :  [=request/window=]
-        :: "no-window"
         :  [=request/service-workers mode=]
         :: "none"
         :  [=request/destination=]


### PR DESCRIPTION
Per https://github.com/whatwg/fetch/pull/1823, this concept is going away. After that change, null-client scenarios will automatically do the right thing, and create no user prompts, which aligns with this spec's desired outcome.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domenic/FedCM/pull/723.html" title="Last updated on May 13, 2025, 5:17 AM UTC (f8fcc6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/723/7ed3425...domenic:f8fcc6c.html" title="Last updated on May 13, 2025, 5:17 AM UTC (f8fcc6c)">Diff</a>