### PR TITLE
Clarify that given_name and name are not to be composed

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2046,9 +2046,11 @@ Every {{IdentityProviderAccount}} is expected to have members with the following
     :   <dfn>username</dfn>
     ::  The user's username.
     :   <dfn>given_name</dfn>
-    ::  The user's given name. Note that `given_name` and `name` are separate fields. Whereas
+    ::  The user's given name. Note that {{IdentityProviderAccount/given_name}} and
+        {{IdentityProviderAccount/name}} are separate fields. Whereas
         {{IdentityProviderAccount/name}} is a full name, {{IdentityProviderAccount/given_name}} may
-        be a nickname. In particular, this means that these two fields should not be composed together.
+        be a nickname. In particular, this means that these two fields should not be composed
+        together.
     :   <dfn>picture</dfn>
     ::  URL for the account's picture.
     :   <dfn>approved_clients</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2046,7 +2046,9 @@ Every {{IdentityProviderAccount}} is expected to have members with the following
     :   <dfn>username</dfn>
     ::  The user's username.
     :   <dfn>given_name</dfn>
-    ::  The user's given name.
+    ::  The user's given name. Note that `given_name` and `name` are separate fields. Whereas
+        {{IdentityProviderAccount/name}} is a full name, {{IdentityProviderAccount/given_name}} may
+        be a nickname. In particular, this means that these two fields should not be composed together.
     :   <dfn>picture</dfn>
     ::  URL for the account's picture.
     :   <dfn>approved_clients</dfn>


### PR DESCRIPTION
Fixes https://github.com/w3c-fedid/FedCM/issues/680
CC @aphillips


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/pull/731.html" title="Last updated on May 30, 2025, 7:32 PM UTC (b6b9c7c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/731/fa550f7...b6b9c7c.html" title="Last updated on May 30, 2025, 7:32 PM UTC (b6b9c7c)">Diff</a>