### PR TITLE
Fix some promise issues in getUserInfo

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1791,60 +1791,78 @@ if (userInfo.length > 0) {
 When invoking the {{IdentityProvider/getUserInfo()}} method given an {{IdentityProviderConfig}}
 |provider|, perform the following steps:
 
-    1. Let |globalObject| be the [=current global object=].
+    1. Let |promise| be a [=new=] {{Promise}} in the [=current global object=]'s [=relevant realm=].
+    1. [=In parallel=], run the [=in parallel steps for getUserInfo=] with |promise| and |provider|.
+    1. Return |promise|.
+</div>
+
+<div algorithm="in parallel steps for getUserInfo">
+The <dfn>in parallel steps for getUserInfo</dfn> given a {{Promise}} |promise| and an
+    {{IdentityProviderConfig}} |provider| are:
     1. Let |document| be |globalObject|'s [=associated Document=].
     1. If |document| is not [=allowed to use=] the [=identity-credentials-get=]
-        [=policy-controlled feature=], throw a "{{NotAllowedError}}" {{DOMException}}.
+        [=policy-controlled feature=], [=queue to reject=] |promise| with "{{NotAllowedError}}"
+        and return.
     1. If there does not exist an account |account| such that [=connected accounts set=]
         [=list/contains=] the result of [=compute the connected account key=] given |account|,
-        |provider|, and |globalObject|, then [=reject=] |promise| with a "{{NetworkError}}"
-        {{DOMException}}. This check can be performed by iterating over the
-        [=connected accounts set=] or by keeping a separate data structure to make this lookup fast.
+        |provider|, and |globalObject|, then [=queue to reject=] |promise| with "{{NetworkError}}"
+        and return. This check can be performed by iterating over the [=connected accounts set=] or
+        by keeping a separate data structure to make this lookup fast.
     1. Let |configUrl| be the result of running [=parse url=] with |provider|'s
         {{IdentityProviderConfig/configURL}} and |globalObject|.
-    1. If |configUrl| is failure, throw an "{{InvalidStateError}}" {{DOMException}}.
+    1. If |configUrl| is failure, [=queue to reject=] |promise| with "{{InvalidStateError}}"
+        and return.
     1. If |document|'s [=Document/origin=] is not [=same origin=] as |configUrl|'s [=url/origin=],
-        throw an "{{InvalidStateError}}" {{DOMException}}.
+        [=queue to reject=] |promise| with "{{InvalidStateError}}" and return.
     1. Run a [[!CSP]] check with a [[CSP#directive-connect-src|connect-src]] directive on the URL
-        passed as |configUrl|. If it fails, throw a new "{{NetworkError}}" {{DOMException}}.
-    1. If |globalObject|'s [=Window/navigable=] is a [=/top-level traversable=], throw a new
-        "{{NetworkError}}" {{DOMException}}.
+        passed as |configUrl|. If it fails, [=queue to reject=] |promise| with "{{NetworkError}}"
+        and return.
+    1. If |globalObject|'s [=Window/navigable=] is a [=/top-level traversable=], [=queue to reject=]
+        |promise| with "{{NetworkError}}" and return.
     1. If the user has disabled the FedCM API on the |globalObject|'s [=Window/navigable=]'s
-        [=navigable/top-level traversable=], throw a new "{{NetworkError}}" {{DOMException}}.
-    1. Let |promise| be a new {{Promise}}.
-    1. Perform the following steps [=in parallel=]:
-        1. Let |config| be the result of running [=fetch the config file=] with |provider| and
-            |globalObject|.
-        1. If |config| is failure, [=reject=] |promise| with a new "{{NetworkError}}"
-            {{DOMException}}.
-        1. Let |accountsList| be the result of [=fetch the accounts=] with |config|, |provider|,
-            and |globalObject|.
-        1. Let |hasAccountEligibleForAutoReauthentication| be false.
-        1. For each |account| in |accountsList|:
-            1. If |account|["{{IdentityProviderAccount/approved_clients}}"] is not empty and it does not
-                [=list/contain=] |provider|'s {{IdentityProviderConfig/clientId}}, continue.
-            
-                Note: this allows the [=IDP=] to override whether an account is a returning account.
-                This could be useful for instance in cases where the user has disconnected the
-                account out of band.
-            
-            1. If |account| is [=eligible for auto reauthentication=] given |provider| and
-                |globalObject|, set |hasAccountEligibleForAutoReauthentication| to true.
-        1. If |hasAccountEligibleForAutoReauthentication| is false, [=reject=] |promise| with a new
-            "{{NetworkError}}" {{DOMException}}.
-        1. Let |userInfoList| be a new [=list=].
-        1. For each |account| in |accountsList|:
-            1. [=list/Append=] an {{IdentityUserInfo}} to |userInfoList| with the following values:
+        [=navigable/top-level traversable=], [=queue to reject=] |promise| with "{{NetworkError}}"
+        and return.
+    1. Let |config| be the result of running [=fetch the config file=] with |provider| and
+        |globalObject|.
+    1. If |config| is failure, [=queue to reject=] |promise| with "{{NetworkError}}" and return.
+    1. Let |accountsList| be the result of [=fetch the accounts=] with |config|, |provider|,
+        and |globalObject|.
+    1. Let |hasAccountEligibleForAutoReauthentication| be false.
+    1. For each |account| in |accountsList|:
+        1. If |account|["{{IdentityProviderAccount/approved_clients}}"] is not empty and it does not
+            [=list/contain=] |provider|'s {{IdentityProviderConfig/clientId}}, continue.
+        
+            Note: this allows the [=IDP=] to override whether an account is a returning account.
+            This could be useful for instance in cases where the user has disconnected the
+            account out of band.
+        
+        1. If |account| is [=eligible for auto reauthentication=] given |provider| and
+            |globalObject|, set |hasAccountEligibleForAutoReauthentication| to true.
+    1. If |hasAccountEligibleForAutoReauthentication| is false, [=queue to reject=] |promise| with
+        "{{NetworkError}}" and return.
+    1. Let |userInfoList| be a new [=list=].
+    1. For each |account| in |accountsList|:
+        1. [=list/Append=] an {{IdentityUserInfo}} to |userInfoList| with the following values:
 
-                :  {{IdentityUserInfo/email}}
-                :: |account|["{{IdentityProviderAccount/email}}"]   
-                :  {{IdentityUserInfo/name}}
-                :: |account|["{{IdentityProviderAccount/name}}"]   
-                :  {{IdentityUserInfo/givenName}}
-                :: |account|["{{IdentityProviderAccount/given_name}}"]   
-                :  {{IdentityUserInfo/picture}}
-                :: |account|["{{IdentityProviderAccount/picture}}"]
-        1. [=Resolve=] a new {{Promise}} with |userInfoList|.
+            :  {{IdentityUserInfo/email}}
+            :: |account|["{{IdentityProviderAccount/email}}"]   
+            :  {{IdentityUserInfo/name}}
+            :: |account|["{{IdentityProviderAccount/name}}"]   
+            :  {{IdentityUserInfo/givenName}}
+            :: |account|["{{IdentityProviderAccount/given_name}}"]   
+            :  {{IdentityUserInfo/picture}}
+            :: |account|["{{IdentityProviderAccount/picture}}"]
+    1. [=Queue a global task=] on the [=DOM manipulation task source=] given |globalObject| to
+        [=resolve=] |promise| with |userInfoList|.
+</div>
+
+<div algorithm="queue to reject">
+When asked to <dfn>queue to reject</dfn> a {{Promise}} |promise| with a name |exceptionName|, run
+the following steps:
+    1. Assert: we are running [=in parallel=].
+    1. Let |globalObject| be |promise|'s [=relevant global object=].
+    1. [=Queue a global task=] on the [=DOM manipulation task source=] given |globalObject| to
+        [=reject=] |promise| with a new |exceptionName| {{DOMException}}.
 </div>
 
 <!-- ============================================================ -->


### PR DESCRIPTION
Make most work be in parallel. Also, queue tasks to reject/resolve the promise as needed. Fixes https://github.com/w3c-fedid/FedCM/issues/727


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/pull/751.html" title="Last updated on Jun 23, 2025, 4:57 PM UTC (4acbc7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/751/7282cc0...4acbc7f.html" title="Last updated on Jun 23, 2025, 4:57 PM UTC (4acbc7f)">Diff</a>