### PR TITLE
Pass IdentityProviderConfig to `fetch the config file`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -529,10 +529,10 @@ When asked to <dfn>attempt to disconnect</dfn> given an {{IdentityCredentialDisc
         |options|, and |globalObject|, then [=reject=] |promise| with a "{{NetworkError}}"
         {{DOMException}}. This check can be performed by iterating over the
         [=connected accounts set=] or by keeping a separate data structure to make this lookup fast.
-    1. Let |config| be the result of running [=fetch the config file=] with
-        |provider| and |globalObject|.
+    1. Let |config| be the result of running [=fetch the config file=] with |options| and
+        |globalObject|.
     1. If |config| is failure, [=reject=] |promise| with a "{{NetworkError}}" {{DOMException}}.
-    1. Let |disconnectUrl| be the result of [=computing the manifest URL=] given |provider|,
+    1. Let |disconnectUrl| be the result of [=computing the manifest URL=] given |options|,
         |config|.{{IdentityProviderAPIConfig/disconnect_endpoint}}, and |globalObject|.
     1. If |disconnectUrl| is failure, [=reject=] |promise| with a "{{NetworkError}}"
         {{DOMException}}.
@@ -1134,7 +1134,7 @@ The <a>fetch the config file</a> algorithm fetches both the [=well-known file=] 
 the [=IDP=], checks that the config file is mentioned in the [=well-known file=], and returns the config.
 
 <div algorithm>
-To <dfn>fetch the config file</dfn> given an {{IdentityProviderRequestOptions}} |provider| and
+To <dfn>fetch the config file</dfn> given an {{IdentityProviderConfig}} |provider| and
 |globalObject|, run the following steps. This returns an {{IdentityProviderAPIConfig}}
 or failure.
     1. Let |configUrl| be the result of running [=parse url=] with |provider|'s


### PR DESCRIPTION
The type passed needs to be IdentityProviderConfig: no other fields are used, and it's not the current type in all existing callers. Also, fix incorrect usage of `provider` in the disconnect algorithm. Fixes https://github.com/w3c-fedid/FedCM/issues/728


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/pull/756.html" title="Last updated on Jul 4, 2025, 7:07 PM UTC (4ba44e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/756/b4933fb...4ba44e4.html" title="Last updated on Jul 4, 2025, 7:07 PM UTC (4ba44e4)">Diff</a>